### PR TITLE
feat: add sync_events audit logging table

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ We take security seriously. If you discover a security vulnerability in Sercha C
 
 Instead, please report them via email to:
 
-**security@custodia.dev**
+**security@sercha.dev**
 
 Include the following information in your report:
 

--- a/cmd/sercha-core/main.go
+++ b/cmd/sercha-core/main.go
@@ -220,6 +220,7 @@ func main() {
 	schedulerStore := postgres.NewSchedulerStore(db)
 	capabilityStore := postgres.NewCapabilityStore(db)
 	searchQueryRepo := postgres.NewSearchQueryRepository(db)
+	syncEventRepo := postgres.NewSyncEventRepository(db)
 
 	// ===== Session Store (Redis if available, otherwise PostgreSQL) =====
 	var sessionStore driven.SessionStore
@@ -619,6 +620,7 @@ func main() {
 		CapabilitySet:    nil, // Built per-execution by executor
 		CapabilityStore:  capabilityStore,
 		SettingsStore:    settingsStore,
+		SyncEventRepo:    syncEventRepo,
 		TeamID:           teamID,
 	})
 

--- a/internal/adapters/driven/postgres/schema.sql
+++ b/internal/adapters/driven/postgres/schema.sql
@@ -406,3 +406,26 @@ CREATE INDEX IF NOT EXISTS idx_oauth_refresh_tokens_access ON oauth_refresh_toke
 CREATE INDEX IF NOT EXISTS idx_oauth_refresh_tokens_client ON oauth_refresh_tokens(client_id);
 CREATE INDEX IF NOT EXISTS idx_oauth_refresh_tokens_user ON oauth_refresh_tokens(user_id);
 CREATE INDEX IF NOT EXISTS idx_oauth_refresh_tokens_expires ON oauth_refresh_tokens(expires_at);
+
+-- Sync events table (for audit logging)
+CREATE TABLE IF NOT EXISTS sync_events (
+    id TEXT PRIMARY KEY,
+    team_id TEXT NOT NULL,
+    source_id TEXT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    source_name TEXT,
+    provider_type TEXT,
+    status TEXT NOT NULL,
+    documents_added INT NOT NULL DEFAULT 0,
+    documents_updated INT NOT NULL DEFAULT 0,
+    documents_deleted INT NOT NULL DEFAULT 0,
+    chunks_indexed INT NOT NULL DEFAULT 0,
+    error_count INT NOT NULL DEFAULT 0,
+    error_message TEXT,
+    duration_seconds DECIMAL(10,2),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_events_team_id ON sync_events(team_id);
+CREATE INDEX IF NOT EXISTS idx_sync_events_source_id ON sync_events(source_id);
+CREATE INDEX IF NOT EXISTS idx_sync_events_created_at ON sync_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_sync_events_team_created ON sync_events(team_id, created_at DESC);

--- a/internal/adapters/driven/postgres/sync_event.go
+++ b/internal/adapters/driven/postgres/sync_event.go
@@ -1,0 +1,189 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/sercha-oss/sercha-core/internal/core/domain"
+	"github.com/sercha-oss/sercha-core/internal/core/ports/driven"
+)
+
+// Verify interface compliance
+var _ driven.SyncEventRepository = (*SyncEventRepository)(nil)
+
+// SyncEventRepository implements driven.SyncEventRepository using PostgreSQL
+type SyncEventRepository struct {
+	db *DB
+}
+
+// NewSyncEventRepository creates a new SyncEventRepository
+func NewSyncEventRepository(db *DB) *SyncEventRepository {
+	return &SyncEventRepository{db: db}
+}
+
+// Save logs a sync event for audit tracking
+func (r *SyncEventRepository) Save(ctx context.Context, event *domain.SyncEvent) error {
+	q := `
+		INSERT INTO sync_events (
+			id, team_id, source_id, source_name, provider_type, status,
+			documents_added, documents_updated, documents_deleted,
+			chunks_indexed, error_count, error_message, duration_seconds,
+			created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+	`
+
+	_, err := r.db.ExecContext(ctx, q,
+		event.ID,
+		event.TeamID,
+		event.SourceID,
+		event.SourceName,
+		string(event.ProviderType),
+		string(event.Status),
+		event.DocumentsAdded,
+		event.DocumentsUpdated,
+		event.DocumentsDeleted,
+		event.ChunksIndexed,
+		event.ErrorCount,
+		event.ErrorMessage,
+		event.DurationSeconds,
+		event.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert sync event: %w", err)
+	}
+
+	return nil
+}
+
+// List retrieves recent sync events for a team
+func (r *SyncEventRepository) List(ctx context.Context, teamID string, limit int) ([]*domain.SyncEvent, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 50
+	}
+
+	q := `
+		SELECT id, team_id, source_id, source_name, provider_type, status,
+		       documents_added, documents_updated, documents_deleted,
+		       chunks_indexed, error_count, error_message, duration_seconds,
+		       created_at
+		FROM sync_events
+		WHERE team_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2
+	`
+
+	rows, err := r.db.QueryContext(ctx, q, teamID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query sync events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var events []*domain.SyncEvent
+	for rows.Next() {
+		var se domain.SyncEvent
+		var providerType string
+		var status string
+		var errorMessage sql.NullString
+
+		err := rows.Scan(
+			&se.ID,
+			&se.TeamID,
+			&se.SourceID,
+			&se.SourceName,
+			&providerType,
+			&status,
+			&se.DocumentsAdded,
+			&se.DocumentsUpdated,
+			&se.DocumentsDeleted,
+			&se.ChunksIndexed,
+			&se.ErrorCount,
+			&errorMessage,
+			&se.DurationSeconds,
+			&se.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scan sync event: %w", err)
+		}
+
+		se.ProviderType = domain.ProviderType(providerType)
+		se.Status = domain.SyncStatus(status)
+		if errorMessage.Valid {
+			se.ErrorMessage = errorMessage.String
+		}
+
+		events = append(events, &se)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sync events: %w", err)
+	}
+
+	return events, nil
+}
+
+// ListBySource retrieves recent sync events for a specific source
+func (r *SyncEventRepository) ListBySource(ctx context.Context, sourceID string, limit int) ([]*domain.SyncEvent, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 50
+	}
+
+	q := `
+		SELECT id, team_id, source_id, source_name, provider_type, status,
+		       documents_added, documents_updated, documents_deleted,
+		       chunks_indexed, error_count, error_message, duration_seconds,
+		       created_at
+		FROM sync_events
+		WHERE source_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2
+	`
+
+	rows, err := r.db.QueryContext(ctx, q, sourceID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query sync events by source: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var events []*domain.SyncEvent
+	for rows.Next() {
+		var se domain.SyncEvent
+		var providerType string
+		var status string
+		var errorMessage sql.NullString
+
+		err := rows.Scan(
+			&se.ID,
+			&se.TeamID,
+			&se.SourceID,
+			&se.SourceName,
+			&providerType,
+			&status,
+			&se.DocumentsAdded,
+			&se.DocumentsUpdated,
+			&se.DocumentsDeleted,
+			&se.ChunksIndexed,
+			&se.ErrorCount,
+			&errorMessage,
+			&se.DurationSeconds,
+			&se.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scan sync event: %w", err)
+		}
+
+		se.ProviderType = domain.ProviderType(providerType)
+		se.Status = domain.SyncStatus(status)
+		if errorMessage.Valid {
+			se.ErrorMessage = errorMessage.String
+		}
+
+		events = append(events, &se)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sync events by source: %w", err)
+	}
+
+	return events, nil
+}

--- a/internal/adapters/driven/postgres/sync_event_test.go
+++ b/internal/adapters/driven/postgres/sync_event_test.go
@@ -1,0 +1,782 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/sercha-oss/sercha-core/internal/core/domain"
+)
+
+// TestSyncEventRepository_Save_Success tests successful save of a sync event
+func TestSyncEventRepository_Save_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	event := &domain.SyncEvent{
+		ID:               "evt-123",
+		TeamID:           "team-456",
+		SourceID:         "src-789",
+		SourceName:       "Test Source",
+		ProviderType:     domain.ProviderTypeGitHub,
+		Status:           domain.SyncStatusCompleted,
+		DocumentsAdded:   10,
+		DocumentsUpdated: 5,
+		DocumentsDeleted: 2,
+		ChunksIndexed:    100,
+		ErrorCount:       0,
+		ErrorMessage:     "",
+		DurationSeconds:  45.5,
+		CreatedAt:        time.Now(),
+	}
+
+	mock.ExpectExec(`INSERT INTO sync_events`).
+		WithArgs(
+			event.ID,
+			event.TeamID,
+			event.SourceID,
+			event.SourceName,
+			string(event.ProviderType),
+			string(event.Status),
+			event.DocumentsAdded,
+			event.DocumentsUpdated,
+			event.DocumentsDeleted,
+			event.ChunksIndexed,
+			event.ErrorCount,
+			event.ErrorMessage,
+			event.DurationSeconds,
+			event.CreatedAt,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Save(context.Background(), event)
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_Save_WithError tests saving a failed sync event with error message
+func TestSyncEventRepository_Save_WithError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	event := &domain.SyncEvent{
+		ID:               "evt-fail-123",
+		TeamID:           "team-456",
+		SourceID:         "src-789",
+		SourceName:       "Failed Source",
+		ProviderType:     domain.ProviderTypeNotion,
+		Status:           domain.SyncStatusFailed,
+		DocumentsAdded:   3,
+		DocumentsUpdated: 1,
+		DocumentsDeleted: 0,
+		ChunksIndexed:    20,
+		ErrorCount:       5,
+		ErrorMessage:     "authentication token expired",
+		DurationSeconds:  10.2,
+		CreatedAt:        time.Now(),
+	}
+
+	mock.ExpectExec(`INSERT INTO sync_events`).
+		WithArgs(
+			event.ID,
+			event.TeamID,
+			event.SourceID,
+			event.SourceName,
+			string(event.ProviderType),
+			string(event.Status),
+			event.DocumentsAdded,
+			event.DocumentsUpdated,
+			event.DocumentsDeleted,
+			event.ChunksIndexed,
+			event.ErrorCount,
+			event.ErrorMessage,
+			event.DurationSeconds,
+			event.CreatedAt,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Save(context.Background(), event)
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_Save_DatabaseError tests error handling for save failures
+func TestSyncEventRepository_Save_DatabaseError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	event := &domain.SyncEvent{
+		ID:               "evt-123",
+		TeamID:           "team-456",
+		SourceID:         "src-789",
+		SourceName:       "Test Source",
+		ProviderType:     domain.ProviderTypeGitHub,
+		Status:           domain.SyncStatusCompleted,
+		DocumentsAdded:   10,
+		DocumentsUpdated: 5,
+		DocumentsDeleted: 2,
+		ChunksIndexed:    100,
+		ErrorCount:       0,
+		ErrorMessage:     "",
+		DurationSeconds:  45.5,
+		CreatedAt:        time.Now(),
+	}
+
+	expectedErr := errors.New("database connection error")
+
+	mock.ExpectExec(`INSERT INTO sync_events`).
+		WithArgs(
+			event.ID,
+			event.TeamID,
+			event.SourceID,
+			event.SourceName,
+			string(event.ProviderType),
+			string(event.Status),
+			event.DocumentsAdded,
+			event.DocumentsUpdated,
+			event.DocumentsDeleted,
+			event.ChunksIndexed,
+			event.ErrorCount,
+			event.ErrorMessage,
+			event.DurationSeconds,
+			event.CreatedAt,
+		).
+		WillReturnError(expectedErr)
+
+	err = repo.Save(context.Background(), event)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_List_Success tests successful retrieval of sync events by team
+func TestSyncEventRepository_List_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	teamID := "team-123"
+	limit := 10
+	createdAt1 := time.Now().Add(-time.Hour)
+	createdAt2 := time.Now().Add(-2 * time.Hour)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "source_id", "source_name", "provider_type", "status",
+		"documents_added", "documents_updated", "documents_deleted",
+		"chunks_indexed", "error_count", "error_message", "duration_seconds",
+		"created_at",
+	}).
+		AddRow("evt-1", teamID, "src-1", "Source 1", "github", "completed",
+			10, 5, 2, 100, 0, nil, 45.5, createdAt1).
+		AddRow("evt-2", teamID, "src-2", "Source 2", "notion", "failed",
+			3, 1, 0, 20, 5, "auth error", 10.2, createdAt2)
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(teamID, limit).
+		WillReturnRows(rows)
+
+	events, err := repo.List(context.Background(), teamID, limit)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	// Verify first event
+	if events[0].ID != "evt-1" {
+		t.Errorf("events[0].ID = %q, want %q", events[0].ID, "evt-1")
+	}
+	if events[0].TeamID != teamID {
+		t.Errorf("events[0].TeamID = %q, want %q", events[0].TeamID, teamID)
+	}
+	if events[0].SourceID != "src-1" {
+		t.Errorf("events[0].SourceID = %q, want %q", events[0].SourceID, "src-1")
+	}
+	if events[0].SourceName != "Source 1" {
+		t.Errorf("events[0].SourceName = %q, want %q", events[0].SourceName, "Source 1")
+	}
+	if events[0].ProviderType != domain.ProviderTypeGitHub {
+		t.Errorf("events[0].ProviderType = %q, want %q", events[0].ProviderType, domain.ProviderTypeGitHub)
+	}
+	if events[0].Status != domain.SyncStatusCompleted {
+		t.Errorf("events[0].Status = %q, want %q", events[0].Status, domain.SyncStatusCompleted)
+	}
+	if events[0].DocumentsAdded != 10 {
+		t.Errorf("events[0].DocumentsAdded = %d, want 10", events[0].DocumentsAdded)
+	}
+	if events[0].ErrorMessage != "" {
+		t.Errorf("events[0].ErrorMessage = %q, want empty", events[0].ErrorMessage)
+	}
+
+	// Verify second event
+	if events[1].ID != "evt-2" {
+		t.Errorf("events[1].ID = %q, want %q", events[1].ID, "evt-2")
+	}
+	if events[1].Status != domain.SyncStatusFailed {
+		t.Errorf("events[1].Status = %q, want %q", events[1].Status, domain.SyncStatusFailed)
+	}
+	if events[1].ErrorCount != 5 {
+		t.Errorf("events[1].ErrorCount = %d, want 5", events[1].ErrorCount)
+	}
+	if events[1].ErrorMessage != "auth error" {
+		t.Errorf("events[1].ErrorMessage = %q, want %q", events[1].ErrorMessage, "auth error")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_List_Empty tests retrieval with no events
+func TestSyncEventRepository_List_Empty(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	teamID := "team-no-events"
+	limit := 10
+
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "source_id", "source_name", "provider_type", "status",
+		"documents_added", "documents_updated", "documents_deleted",
+		"chunks_indexed", "error_count", "error_message", "duration_seconds",
+		"created_at",
+	})
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(teamID, limit).
+		WillReturnRows(rows)
+
+	events, err := repo.List(context.Background(), teamID, limit)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	if len(events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(events))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_List_LimitClamping tests that invalid limits are clamped
+func TestSyncEventRepository_List_LimitClamping(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputLimit    int
+		expectedLimit int
+	}{
+		{
+			name:          "zero limit defaults to 50",
+			inputLimit:    0,
+			expectedLimit: 50,
+		},
+		{
+			name:          "negative limit defaults to 50",
+			inputLimit:    -10,
+			expectedLimit: 50,
+		},
+		{
+			name:          "limit over 100 clamped to 50",
+			inputLimit:    150,
+			expectedLimit: 50,
+		},
+		{
+			name:          "valid limit preserved",
+			inputLimit:    25,
+			expectedLimit: 25,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("failed to create mock db: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			repo := NewSyncEventRepository(&DB{DB: db})
+
+			rows := sqlmock.NewRows([]string{
+				"id", "team_id", "source_id", "source_name", "provider_type", "status",
+				"documents_added", "documents_updated", "documents_deleted",
+				"chunks_indexed", "error_count", "error_message", "duration_seconds",
+				"created_at",
+			})
+
+			mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+				WithArgs("team-123", tt.expectedLimit).
+				WillReturnRows(rows)
+
+			_, err = repo.List(context.Background(), "team-123", tt.inputLimit)
+			if err != nil {
+				t.Fatalf("List failed: %v", err)
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unfulfilled expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestSyncEventRepository_List_DatabaseError tests error handling for query failures
+func TestSyncEventRepository_List_DatabaseError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	teamID := "team-123"
+	limit := 10
+	expectedErr := errors.New("database connection error")
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(teamID, limit).
+		WillReturnError(expectedErr)
+
+	events, err := repo.List(context.Background(), teamID, limit)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if events != nil {
+		t.Errorf("expected nil events on error, got %v", events)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_List_ScanError tests error handling for row scan failures
+func TestSyncEventRepository_List_ScanError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	teamID := "team-123"
+	limit := 10
+
+	// Return invalid data that will fail to scan
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "source_id", "source_name", "provider_type", "status",
+		"documents_added", "documents_updated", "documents_deleted",
+		"chunks_indexed", "error_count", "error_message", "duration_seconds",
+		"created_at",
+	}).
+		AddRow("evt-1", teamID, "src-1", "Source 1", "github", "completed",
+			"INVALID", 5, 2, 100, 0, nil, 45.5, time.Now()) // documents_added is string instead of int
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(teamID, limit).
+		WillReturnRows(rows)
+
+	events, err := repo.List(context.Background(), teamID, limit)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if events != nil {
+		t.Errorf("expected nil events on error, got %v", events)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_ListBySource_Success tests successful retrieval of sync events by source
+func TestSyncEventRepository_ListBySource_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	sourceID := "src-123"
+	limit := 5
+	createdAt1 := time.Now().Add(-time.Hour)
+	createdAt2 := time.Now().Add(-2 * time.Hour)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "source_id", "source_name", "provider_type", "status",
+		"documents_added", "documents_updated", "documents_deleted",
+		"chunks_indexed", "error_count", "error_message", "duration_seconds",
+		"created_at",
+	}).
+		AddRow("evt-1", "team-1", sourceID, "My Source", "github", "completed",
+			15, 8, 3, 150, 0, nil, 60.0, createdAt1).
+		AddRow("evt-2", "team-1", sourceID, "My Source", "github", "completed",
+			5, 2, 1, 50, 0, nil, 30.5, createdAt2)
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(sourceID, limit).
+		WillReturnRows(rows)
+
+	events, err := repo.ListBySource(context.Background(), sourceID, limit)
+	if err != nil {
+		t.Fatalf("ListBySource failed: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	// Verify both events have the same source ID
+	for i, event := range events {
+		if event.SourceID != sourceID {
+			t.Errorf("events[%d].SourceID = %q, want %q", i, event.SourceID, sourceID)
+		}
+	}
+
+	// Verify first event details
+	if events[0].ID != "evt-1" {
+		t.Errorf("events[0].ID = %q, want %q", events[0].ID, "evt-1")
+	}
+	if events[0].DocumentsAdded != 15 {
+		t.Errorf("events[0].DocumentsAdded = %d, want 15", events[0].DocumentsAdded)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_ListBySource_Empty tests retrieval with no events for source
+func TestSyncEventRepository_ListBySource_Empty(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	sourceID := "src-no-events"
+	limit := 10
+
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "source_id", "source_name", "provider_type", "status",
+		"documents_added", "documents_updated", "documents_deleted",
+		"chunks_indexed", "error_count", "error_message", "duration_seconds",
+		"created_at",
+	})
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(sourceID, limit).
+		WillReturnRows(rows)
+
+	events, err := repo.ListBySource(context.Background(), sourceID, limit)
+	if err != nil {
+		t.Fatalf("ListBySource failed: %v", err)
+	}
+
+	if len(events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(events))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_ListBySource_LimitClamping tests that invalid limits are clamped
+func TestSyncEventRepository_ListBySource_LimitClamping(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputLimit    int
+		expectedLimit int
+	}{
+		{
+			name:          "zero limit defaults to 50",
+			inputLimit:    0,
+			expectedLimit: 50,
+		},
+		{
+			name:          "negative limit defaults to 50",
+			inputLimit:    -5,
+			expectedLimit: 50,
+		},
+		{
+			name:          "limit over 100 clamped to 50",
+			inputLimit:    200,
+			expectedLimit: 50,
+		},
+		{
+			name:          "valid limit preserved",
+			inputLimit:    30,
+			expectedLimit: 30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("failed to create mock db: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			repo := NewSyncEventRepository(&DB{DB: db})
+
+			rows := sqlmock.NewRows([]string{
+				"id", "team_id", "source_id", "source_name", "provider_type", "status",
+				"documents_added", "documents_updated", "documents_deleted",
+				"chunks_indexed", "error_count", "error_message", "duration_seconds",
+				"created_at",
+			})
+
+			mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+				WithArgs("src-123", tt.expectedLimit).
+				WillReturnRows(rows)
+
+			_, err = repo.ListBySource(context.Background(), "src-123", tt.inputLimit)
+			if err != nil {
+				t.Fatalf("ListBySource failed: %v", err)
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unfulfilled expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestSyncEventRepository_ListBySource_DatabaseError tests error handling for query failures
+func TestSyncEventRepository_ListBySource_DatabaseError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	sourceID := "src-123"
+	limit := 10
+	expectedErr := errors.New("database timeout")
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(sourceID, limit).
+		WillReturnError(expectedErr)
+
+	events, err := repo.ListBySource(context.Background(), sourceID, limit)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if events != nil {
+		t.Errorf("expected nil events on error, got %v", events)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_InterfaceCompliance verifies the repository implements the interface
+func TestSyncEventRepository_InterfaceCompliance(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// This will fail to compile if the interface is not properly implemented
+	repo := NewSyncEventRepository(&DB{DB: db})
+	if repo == nil {
+		t.Fatal("expected non-nil repository")
+	}
+}
+
+// TestSyncEventRepository_RoundTrip tests saving and retrieving sync events
+func TestSyncEventRepository_RoundTrip(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	originalEvent := &domain.SyncEvent{
+		ID:               "evt-roundtrip",
+		TeamID:           "team-rt",
+		SourceID:         "src-rt",
+		SourceName:       "RoundTrip Source",
+		ProviderType:     domain.ProviderTypeGitHub,
+		Status:           domain.SyncStatusCompleted,
+		DocumentsAdded:   25,
+		DocumentsUpdated: 15,
+		DocumentsDeleted: 5,
+		ChunksIndexed:    300,
+		ErrorCount:       0,
+		ErrorMessage:     "",
+		DurationSeconds:  90.5,
+		CreatedAt:        time.Now().Truncate(time.Microsecond), // Postgres precision
+	}
+
+	// Mock save
+	mock.ExpectExec(`INSERT INTO sync_events`).
+		WithArgs(
+			originalEvent.ID,
+			originalEvent.TeamID,
+			originalEvent.SourceID,
+			originalEvent.SourceName,
+			string(originalEvent.ProviderType),
+			string(originalEvent.Status),
+			originalEvent.DocumentsAdded,
+			originalEvent.DocumentsUpdated,
+			originalEvent.DocumentsDeleted,
+			originalEvent.ChunksIndexed,
+			originalEvent.ErrorCount,
+			originalEvent.ErrorMessage,
+			originalEvent.DurationSeconds,
+			originalEvent.CreatedAt,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Save(context.Background(), originalEvent)
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Mock retrieve by team
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "source_id", "source_name", "provider_type", "status",
+		"documents_added", "documents_updated", "documents_deleted",
+		"chunks_indexed", "error_count", "error_message", "duration_seconds",
+		"created_at",
+	}).
+		AddRow(
+			originalEvent.ID,
+			originalEvent.TeamID,
+			originalEvent.SourceID,
+			originalEvent.SourceName,
+			string(originalEvent.ProviderType),
+			string(originalEvent.Status),
+			originalEvent.DocumentsAdded,
+			originalEvent.DocumentsUpdated,
+			originalEvent.DocumentsDeleted,
+			originalEvent.ChunksIndexed,
+			originalEvent.ErrorCount,
+			sql.NullString{}, // Empty error message
+			originalEvent.DurationSeconds,
+			originalEvent.CreatedAt,
+		)
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(originalEvent.TeamID, 50).
+		WillReturnRows(rows)
+
+	events, err := repo.List(context.Background(), originalEvent.TeamID, 50)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	retrievedEvent := events[0]
+
+	// Verify all fields match
+	if retrievedEvent.ID != originalEvent.ID {
+		t.Errorf("ID = %q, want %q", retrievedEvent.ID, originalEvent.ID)
+	}
+	if retrievedEvent.TeamID != originalEvent.TeamID {
+		t.Errorf("TeamID = %q, want %q", retrievedEvent.TeamID, originalEvent.TeamID)
+	}
+	if retrievedEvent.SourceID != originalEvent.SourceID {
+		t.Errorf("SourceID = %q, want %q", retrievedEvent.SourceID, originalEvent.SourceID)
+	}
+	if retrievedEvent.SourceName != originalEvent.SourceName {
+		t.Errorf("SourceName = %q, want %q", retrievedEvent.SourceName, originalEvent.SourceName)
+	}
+	if retrievedEvent.ProviderType != originalEvent.ProviderType {
+		t.Errorf("ProviderType = %q, want %q", retrievedEvent.ProviderType, originalEvent.ProviderType)
+	}
+	if retrievedEvent.Status != originalEvent.Status {
+		t.Errorf("Status = %q, want %q", retrievedEvent.Status, originalEvent.Status)
+	}
+	if retrievedEvent.DocumentsAdded != originalEvent.DocumentsAdded {
+		t.Errorf("DocumentsAdded = %d, want %d", retrievedEvent.DocumentsAdded, originalEvent.DocumentsAdded)
+	}
+	if retrievedEvent.DocumentsUpdated != originalEvent.DocumentsUpdated {
+		t.Errorf("DocumentsUpdated = %d, want %d", retrievedEvent.DocumentsUpdated, originalEvent.DocumentsUpdated)
+	}
+	if retrievedEvent.DocumentsDeleted != originalEvent.DocumentsDeleted {
+		t.Errorf("DocumentsDeleted = %d, want %d", retrievedEvent.DocumentsDeleted, originalEvent.DocumentsDeleted)
+	}
+	if retrievedEvent.ChunksIndexed != originalEvent.ChunksIndexed {
+		t.Errorf("ChunksIndexed = %d, want %d", retrievedEvent.ChunksIndexed, originalEvent.ChunksIndexed)
+	}
+	if retrievedEvent.ErrorCount != originalEvent.ErrorCount {
+		t.Errorf("ErrorCount = %d, want %d", retrievedEvent.ErrorCount, originalEvent.ErrorCount)
+	}
+	if retrievedEvent.ErrorMessage != originalEvent.ErrorMessage {
+		t.Errorf("ErrorMessage = %q, want %q", retrievedEvent.ErrorMessage, originalEvent.ErrorMessage)
+	}
+	if retrievedEvent.DurationSeconds != originalEvent.DurationSeconds {
+		t.Errorf("DurationSeconds = %f, want %f", retrievedEvent.DurationSeconds, originalEvent.DurationSeconds)
+	}
+	if !retrievedEvent.CreatedAt.Equal(originalEvent.CreatedAt) {
+		t.Errorf("CreatedAt = %v, want %v", retrievedEvent.CreatedAt, originalEvent.CreatedAt)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}

--- a/internal/core/domain/sync_event.go
+++ b/internal/core/domain/sync_event.go
@@ -1,0 +1,102 @@
+package domain
+
+import "time"
+
+// SyncEvent represents a logged sync operation for audit and analytics
+// This is an entity (has identity) used to track sync history and performance
+type SyncEvent struct {
+	// ID is the unique identifier for this sync event log entry
+	ID string `json:"id"`
+
+	// TeamID is the team that owns the source being synced
+	TeamID string `json:"team_id"`
+
+	// SourceID is the source that was synced
+	SourceID string `json:"source_id"`
+
+	// SourceName is the display name of the source at sync time
+	SourceName string `json:"source_name"`
+
+	// ProviderType identifies the connector type (github, notion, etc.)
+	ProviderType ProviderType `json:"provider_type"`
+
+	// Status indicates if the sync completed successfully or failed
+	Status SyncStatus `json:"status"`
+
+	// DocumentsAdded is the number of new documents discovered
+	DocumentsAdded int `json:"documents_added"`
+
+	// DocumentsUpdated is the number of existing documents modified
+	DocumentsUpdated int `json:"documents_updated"`
+
+	// DocumentsDeleted is the number of documents removed
+	DocumentsDeleted int `json:"documents_deleted"`
+
+	// ChunksIndexed is the total number of chunks created/updated in the vector store
+	ChunksIndexed int `json:"chunks_indexed"`
+
+	// ErrorCount is the number of errors encountered during sync
+	ErrorCount int `json:"error_count"`
+
+	// ErrorMessage contains the primary error message if Status is failed
+	ErrorMessage string `json:"error_message,omitempty"`
+
+	// DurationSeconds is how long the sync operation took to execute
+	DurationSeconds float64 `json:"duration_seconds"`
+
+	// CreatedAt is when the sync event was logged
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// NewSyncEvent creates a new sync event log entry for a completed sync
+func NewSyncEvent(
+	teamID string,
+	sourceID string,
+	sourceName string,
+	providerType ProviderType,
+	status SyncStatus,
+	stats SyncStats,
+	durationSeconds float64,
+) *SyncEvent {
+	return &SyncEvent{
+		ID:               GenerateID(),
+		TeamID:           teamID,
+		SourceID:         sourceID,
+		SourceName:       sourceName,
+		ProviderType:     providerType,
+		Status:           status,
+		DocumentsAdded:   stats.DocumentsAdded,
+		DocumentsUpdated: stats.DocumentsUpdated,
+		DocumentsDeleted: stats.DocumentsDeleted,
+		ChunksIndexed:    stats.ChunksIndexed,
+		ErrorCount:       stats.Errors,
+		DurationSeconds:  durationSeconds,
+		CreatedAt:        time.Now(),
+	}
+}
+
+// WithError sets the error message for a failed sync event
+func (se *SyncEvent) WithError(errMsg string) *SyncEvent {
+	se.ErrorMessage = errMsg
+	return se
+}
+
+// IsSuccessful returns true if the sync completed without failure
+func (se *SyncEvent) IsSuccessful() bool {
+	return se.Status == SyncStatusCompleted
+}
+
+// IsFailed returns true if the sync failed
+func (se *SyncEvent) IsFailed() bool {
+	return se.Status == SyncStatusFailed
+}
+
+// TotalDocuments returns the total number of documents affected by the sync
+func (se *SyncEvent) TotalDocuments() int {
+	return se.DocumentsAdded + se.DocumentsUpdated + se.DocumentsDeleted
+}
+
+// GetDuration returns the duration as a time.Duration
+func (se *SyncEvent) GetDuration() time.Duration {
+	return time.Duration(se.DurationSeconds * float64(time.Second))
+}

--- a/internal/core/domain/sync_event_test.go
+++ b/internal/core/domain/sync_event_test.go
@@ -1,0 +1,431 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewSyncEvent(t *testing.T) {
+	teamID := "team-123"
+	sourceID := "source-456"
+	sourceName := "Test Source"
+	providerType := ProviderTypeGitHub
+	status := SyncStatusCompleted
+	stats := SyncStats{
+		DocumentsAdded:   10,
+		DocumentsUpdated: 5,
+		DocumentsDeleted: 2,
+		ChunksIndexed:    100,
+		Errors:           0,
+	}
+	duration := 45.5
+
+	event := NewSyncEvent(teamID, sourceID, sourceName, providerType, status, stats, duration)
+
+	if event.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if event.TeamID != teamID {
+		t.Errorf("expected team ID %s, got %s", teamID, event.TeamID)
+	}
+	if event.SourceID != sourceID {
+		t.Errorf("expected source ID %s, got %s", sourceID, event.SourceID)
+	}
+	if event.SourceName != sourceName {
+		t.Errorf("expected source name %s, got %s", sourceName, event.SourceName)
+	}
+	if event.ProviderType != providerType {
+		t.Errorf("expected provider type %s, got %s", providerType, event.ProviderType)
+	}
+	if event.Status != status {
+		t.Errorf("expected status %s, got %s", status, event.Status)
+	}
+	if event.DocumentsAdded != stats.DocumentsAdded {
+		t.Errorf("expected documents added %d, got %d", stats.DocumentsAdded, event.DocumentsAdded)
+	}
+	if event.DocumentsUpdated != stats.DocumentsUpdated {
+		t.Errorf("expected documents updated %d, got %d", stats.DocumentsUpdated, event.DocumentsUpdated)
+	}
+	if event.DocumentsDeleted != stats.DocumentsDeleted {
+		t.Errorf("expected documents deleted %d, got %d", stats.DocumentsDeleted, event.DocumentsDeleted)
+	}
+	if event.ChunksIndexed != stats.ChunksIndexed {
+		t.Errorf("expected chunks indexed %d, got %d", stats.ChunksIndexed, event.ChunksIndexed)
+	}
+	if event.ErrorCount != stats.Errors {
+		t.Errorf("expected error count %d, got %d", stats.Errors, event.ErrorCount)
+	}
+	if event.DurationSeconds != duration {
+		t.Errorf("expected duration %f, got %f", duration, event.DurationSeconds)
+	}
+	if event.CreatedAt.IsZero() {
+		t.Error("expected non-zero CreatedAt")
+	}
+	if event.ErrorMessage != "" {
+		t.Error("expected empty error message for successful sync")
+	}
+}
+
+func TestNewSyncEvent_WithErrors(t *testing.T) {
+	stats := SyncStats{
+		DocumentsAdded:   8,
+		DocumentsUpdated: 3,
+		DocumentsDeleted: 1,
+		ChunksIndexed:    50,
+		Errors:           3,
+	}
+
+	event := NewSyncEvent("team-1", "src-1", "Source", ProviderTypeNotion, SyncStatusCompleted, stats, 60.0)
+
+	if event.ErrorCount != 3 {
+		t.Errorf("expected error count 3, got %d", event.ErrorCount)
+	}
+	if event.ErrorMessage != "" {
+		t.Error("expected empty error message (set via WithError)")
+	}
+}
+
+func TestSyncEvent_WithError(t *testing.T) {
+	event := NewSyncEvent(
+		"team-1",
+		"src-1",
+		"Source",
+		ProviderTypeGitHub,
+		SyncStatusFailed,
+		SyncStats{Errors: 1},
+		30.0,
+	)
+
+	errorMsg := "failed to fetch documents"
+	result := event.WithError(errorMsg)
+
+	if result.ErrorMessage != errorMsg {
+		t.Errorf("expected error message %s, got %s", errorMsg, result.ErrorMessage)
+	}
+	// Verify it returns the same instance
+	if result != event {
+		t.Error("expected WithError to return the same instance")
+	}
+}
+
+func TestSyncEvent_IsSuccessful(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   SyncStatus
+		expected bool
+	}{
+		{
+			name:     "completed status is successful",
+			status:   SyncStatusCompleted,
+			expected: true,
+		},
+		{
+			name:     "failed status is not successful",
+			status:   SyncStatusFailed,
+			expected: false,
+		},
+		{
+			name:     "running status is not successful",
+			status:   SyncStatusRunning,
+			expected: false,
+		},
+		{
+			name:     "idle status is not successful",
+			status:   SyncStatusIdle,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &SyncEvent{Status: tt.status}
+			if got := event.IsSuccessful(); got != tt.expected {
+				t.Errorf("expected IsSuccessful() = %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestSyncEvent_IsFailed(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   SyncStatus
+		expected bool
+	}{
+		{
+			name:     "failed status is failed",
+			status:   SyncStatusFailed,
+			expected: true,
+		},
+		{
+			name:     "completed status is not failed",
+			status:   SyncStatusCompleted,
+			expected: false,
+		},
+		{
+			name:     "running status is not failed",
+			status:   SyncStatusRunning,
+			expected: false,
+		},
+		{
+			name:     "idle status is not failed",
+			status:   SyncStatusIdle,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &SyncEvent{Status: tt.status}
+			if got := event.IsFailed(); got != tt.expected {
+				t.Errorf("expected IsFailed() = %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestSyncEvent_TotalDocuments(t *testing.T) {
+	tests := []struct {
+		name     string
+		added    int
+		updated  int
+		deleted  int
+		expected int
+	}{
+		{
+			name:     "all zeros",
+			added:    0,
+			updated:  0,
+			deleted:  0,
+			expected: 0,
+		},
+		{
+			name:     "only added",
+			added:    10,
+			updated:  0,
+			deleted:  0,
+			expected: 10,
+		},
+		{
+			name:     "only updated",
+			added:    0,
+			updated:  5,
+			deleted:  0,
+			expected: 5,
+		},
+		{
+			name:     "only deleted",
+			added:    0,
+			updated:  0,
+			deleted:  3,
+			expected: 3,
+		},
+		{
+			name:     "mixed documents",
+			added:    10,
+			updated:  5,
+			deleted:  2,
+			expected: 17,
+		},
+		{
+			name:     "large numbers",
+			added:    1000,
+			updated:  500,
+			deleted:  200,
+			expected: 1700,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &SyncEvent{
+				DocumentsAdded:   tt.added,
+				DocumentsUpdated: tt.updated,
+				DocumentsDeleted: tt.deleted,
+			}
+			if got := event.TotalDocuments(); got != tt.expected {
+				t.Errorf("expected TotalDocuments() = %d, got %d", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestSyncEvent_GetDuration(t *testing.T) {
+	tests := []struct {
+		name            string
+		durationSeconds float64
+		expected        time.Duration
+	}{
+		{
+			name:            "zero duration",
+			durationSeconds: 0.0,
+			expected:        0,
+		},
+		{
+			name:            "one second",
+			durationSeconds: 1.0,
+			expected:        time.Second,
+		},
+		{
+			name:            "fractional seconds",
+			durationSeconds: 1.5,
+			expected:        1500 * time.Millisecond,
+		},
+		{
+			name:            "one minute",
+			durationSeconds: 60.0,
+			expected:        time.Minute,
+		},
+		{
+			name:            "large duration",
+			durationSeconds: 3600.0,
+			expected:        time.Hour,
+		},
+		{
+			name:            "milliseconds precision",
+			durationSeconds: 0.123,
+			expected:        123 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &SyncEvent{DurationSeconds: tt.durationSeconds}
+			got := event.GetDuration()
+			if got != tt.expected {
+				t.Errorf("expected GetDuration() = %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestSyncEvent_CompleteSyncScenario(t *testing.T) {
+	// Simulate a complete successful sync
+	teamID := "team-prod-123"
+	sourceID := "github-repo-456"
+	sourceName := "MyOrg/MyRepo"
+	providerType := ProviderTypeGitHub
+	stats := SyncStats{
+		DocumentsAdded:   25,
+		DocumentsUpdated: 10,
+		DocumentsDeleted: 3,
+		ChunksIndexed:    500,
+		Errors:           0,
+	}
+	duration := 120.5
+
+	event := NewSyncEvent(teamID, sourceID, sourceName, providerType, SyncStatusCompleted, stats, duration)
+
+	// Verify event structure
+	if !event.IsSuccessful() {
+		t.Error("expected successful sync")
+	}
+	if event.IsFailed() {
+		t.Error("expected not failed")
+	}
+	if event.TotalDocuments() != 38 {
+		t.Errorf("expected total documents 38, got %d", event.TotalDocuments())
+	}
+	if event.GetDuration() != 120*time.Second+500*time.Millisecond {
+		t.Errorf("expected duration 120.5s, got %v", event.GetDuration())
+	}
+	if event.ErrorMessage != "" {
+		t.Error("expected no error message for successful sync")
+	}
+}
+
+func TestSyncEvent_FailedSyncScenario(t *testing.T) {
+	// Simulate a failed sync
+	teamID := "team-dev-789"
+	sourceID := "notion-workspace-012"
+	sourceName := "Dev Workspace"
+	providerType := ProviderTypeNotion
+	stats := SyncStats{
+		DocumentsAdded:   5,
+		DocumentsUpdated: 2,
+		DocumentsDeleted: 0,
+		ChunksIndexed:    50,
+		Errors:           10,
+	}
+	duration := 45.2
+	errorMsg := "authentication token expired"
+
+	event := NewSyncEvent(teamID, sourceID, sourceName, providerType, SyncStatusFailed, stats, duration).
+		WithError(errorMsg)
+
+	// Verify event structure
+	if event.IsSuccessful() {
+		t.Error("expected not successful")
+	}
+	if !event.IsFailed() {
+		t.Error("expected failed sync")
+	}
+	if event.ErrorCount != 10 {
+		t.Errorf("expected error count 10, got %d", event.ErrorCount)
+	}
+	if event.ErrorMessage != errorMsg {
+		t.Errorf("expected error message %s, got %s", errorMsg, event.ErrorMessage)
+	}
+	if event.TotalDocuments() != 7 {
+		t.Errorf("expected total documents 7, got %d", event.TotalDocuments())
+	}
+}
+
+func TestSyncEvent_ZeroStatsScenario(t *testing.T) {
+	// Simulate a sync with no changes (all documents up to date)
+	event := NewSyncEvent(
+		"team-1",
+		"src-1",
+		"No Changes Source",
+		ProviderTypeGitHub,
+		SyncStatusCompleted,
+		SyncStats{
+			DocumentsAdded:   0,
+			DocumentsUpdated: 0,
+			DocumentsDeleted: 0,
+			ChunksIndexed:    0,
+			Errors:           0,
+		},
+		10.0,
+	)
+
+	if !event.IsSuccessful() {
+		t.Error("expected successful sync even with zero stats")
+	}
+	if event.TotalDocuments() != 0 {
+		t.Errorf("expected total documents 0, got %d", event.TotalDocuments())
+	}
+	if event.ErrorCount != 0 {
+		t.Errorf("expected error count 0, got %d", event.ErrorCount)
+	}
+}
+
+func TestSyncEvent_IDUniqueness(t *testing.T) {
+	// Verify that each new event gets a unique ID
+	event1 := NewSyncEvent("team-1", "src-1", "Source 1", ProviderTypeGitHub, SyncStatusCompleted, SyncStats{}, 10.0)
+	event2 := NewSyncEvent("team-1", "src-1", "Source 1", ProviderTypeGitHub, SyncStatusCompleted, SyncStats{}, 10.0)
+
+	if event1.ID == "" {
+		t.Error("expected non-empty ID for event1")
+	}
+	if event2.ID == "" {
+		t.Error("expected non-empty ID for event2")
+	}
+	if event1.ID == event2.ID {
+		t.Error("expected unique IDs for different events")
+	}
+	// Base64 URL encoding of 16 bytes = 22 chars (same as GenerateID)
+	if len(event1.ID) != 22 {
+		t.Errorf("expected ID length 22, got %d", len(event1.ID))
+	}
+}
+
+func TestSyncEvent_CreatedAtTimestamp(t *testing.T) {
+	before := time.Now()
+	event := NewSyncEvent("team-1", "src-1", "Source", ProviderTypeGitHub, SyncStatusCompleted, SyncStats{}, 10.0)
+	after := time.Now()
+
+	if event.CreatedAt.Before(before) || event.CreatedAt.After(after.Add(time.Second)) {
+		t.Error("expected CreatedAt to be close to now")
+	}
+}

--- a/internal/core/ports/driven/sync_event_repository.go
+++ b/internal/core/ports/driven/sync_event_repository.go
@@ -1,0 +1,21 @@
+package driven
+
+import (
+	"context"
+
+	"github.com/sercha-oss/sercha-core/internal/core/domain"
+)
+
+// SyncEventRepository handles sync event logging and audit trails
+type SyncEventRepository interface {
+	// Save logs a sync event for audit tracking
+	Save(ctx context.Context, event *domain.SyncEvent) error
+
+	// List retrieves recent sync events for a team
+	// Returns up to limit most recent events, ordered by created_at desc
+	List(ctx context.Context, teamID string, limit int) ([]*domain.SyncEvent, error)
+
+	// ListBySource retrieves recent sync events for a specific source
+	// Returns up to limit most recent events, ordered by created_at desc
+	ListBySource(ctx context.Context, sourceID string, limit int) ([]*domain.SyncEvent, error)
+}

--- a/internal/core/services/sync.go
+++ b/internal/core/services/sync.go
@@ -36,6 +36,7 @@ type SyncOrchestrator struct {
 	capabilitySet    *pipeline.CapabilitySet       // Capabilities for pipeline
 	capabilityStore  driven.CapabilityStore        // For fetching capability preferences
 	settingsStore    driven.SettingsStore          // For loading team settings
+	syncEventRepo    driven.SyncEventRepository    // For audit logging of sync events
 	teamID           string                        // Team ID for settings lookup
 }
 
@@ -54,6 +55,7 @@ type SyncOrchestratorConfig struct {
 	CapabilitySet    *pipeline.CapabilitySet       // Capabilities for pipeline
 	CapabilityStore  driven.CapabilityStore        // For fetching capability preferences
 	SettingsStore    driven.SettingsStore          // For loading team settings
+	SyncEventRepo    driven.SyncEventRepository    // For audit logging of sync events
 	TeamID           string                        // Team ID for settings lookup
 }
 
@@ -83,6 +85,7 @@ func NewSyncOrchestrator(cfg SyncOrchestratorConfig) *SyncOrchestrator {
 		capabilitySet:    cfg.CapabilitySet,
 		capabilityStore:  cfg.CapabilityStore,
 		settingsStore:    cfg.SettingsStore,
+		syncEventRepo:    cfg.SyncEventRepo,
 		teamID:           cfg.TeamID,
 	}
 }
@@ -346,6 +349,25 @@ func (o *SyncOrchestrator) SyncSource(ctx context.Context, sourceID string) (*do
 		"chunks_indexed", aggregatedStats.ChunksIndexed,
 		"errors", aggregatedStats.Errors,
 	)
+
+	// Log sync event for audit trail
+	if o.syncEventRepo != nil {
+		syncEvent := domain.NewSyncEvent(
+			o.teamID,
+			sourceID,
+			source.Name,
+			source.ProviderType,
+			syncState.Status,
+			aggregatedStats,
+			duration,
+		)
+		if syncState.Error != "" {
+			syncEvent.WithError(syncState.Error)
+		}
+		if err := o.syncEventRepo.Save(ctx, syncEvent); err != nil {
+			o.logger.Warn("failed to save sync event", "error", err)
+		}
+	}
 
 	success := syncState.Status == domain.SyncStatusCompleted && syncState.Error == ""
 	return &domain.SyncResult{
@@ -745,6 +767,26 @@ func (o *SyncOrchestrator) failSync(
 		syncState.CompletedAt = &now
 		syncState.Error = err.Error()
 		_ = o.syncStore.Save(ctx, syncState)
+	}
+
+	// Log sync event for audit trail
+	if o.syncEventRepo != nil {
+		// Get source info for event logging
+		source, sourceErr := o.sourceStore.Get(ctx, sourceID)
+		if sourceErr == nil {
+			syncEvent := domain.NewSyncEvent(
+				o.teamID,
+				sourceID,
+				source.Name,
+				source.ProviderType,
+				domain.SyncStatusFailed,
+				domain.SyncStats{}, // Empty stats for failed sync
+				duration,
+			).WithError(err.Error())
+			if saveErr := o.syncEventRepo.Save(ctx, syncEvent); saveErr != nil {
+				o.logger.Warn("failed to save sync event", "error", saveErr)
+			}
+		}
 	}
 
 	return &domain.SyncResult{


### PR DESCRIPTION
## Summary

Add persistent audit logging for sync operations via a `sync_events` table, mirroring the existing `search_queries` pattern.

## Motivation

For team deployments, administrators need:
- Queryable history of sync operations
- Audit trail of what was synced, when, and success/failure status
- Basic compliance/SIEM integration capability

Without persistent sync event logging, the OSS is not operatable in any serious team context.

## Changes

- Add `SyncEvent` domain model with status, stats, and error tracking
- Add `SyncEventRepository` port interface
- Add Postgres adapter implementation
- Add `sync_events` table to schema.sql with proper indexes
- Wire up event logging in `SyncOrchestrator` on completion/failure
- Update SECURITY.md contact email

## Testing

- [x] Unit tests added/updated
- [x] Integration tests pass (if applicable)
- [x] Manual testing performed
- [x] Tested Docker build

**Test commands:**
```bash
go test ./...                    # Unit tests
cd tests/integration && make test  # Integration tests (if applicable)
```

## Checklist

- [x] Code follows project conventions
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in commits with `!`)
- [x] CI passes

## Related Issues

Fixes #70