### PR TITLE
feat(mcp): add URL field to get_document tool output

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ We take security seriously. If you discover a security vulnerability in Sercha C
 
 Instead, please report them via email to:
 
-**security@custodia.dev**
+**security@sercha.dev**
 
 Include the following information in your report:
 

--- a/cmd/sercha-core/main.go
+++ b/cmd/sercha-core/main.go
@@ -220,6 +220,7 @@ func main() {
 	schedulerStore := postgres.NewSchedulerStore(db)
 	capabilityStore := postgres.NewCapabilityStore(db)
 	searchQueryRepo := postgres.NewSearchQueryRepository(db)
+	syncEventRepo := postgres.NewSyncEventRepository(db)
 
 	// ===== Session Store (Redis if available, otherwise PostgreSQL) =====
 	var sessionStore driven.SessionStore
@@ -619,6 +620,7 @@ func main() {
 		CapabilitySet:    nil, // Built per-execution by executor
 		CapabilityStore:  capabilityStore,
 		SettingsStore:    settingsStore,
+		SyncEventRepo:    syncEventRepo,
 		TeamID:           teamID,
 	})
 

--- a/internal/adapters/driven/opensearch/search_engine.go
+++ b/internal/adapters/driven/opensearch/search_engine.go
@@ -167,6 +167,22 @@ func (s *SearchEngine) SearchDocuments(ctx context.Context, query string, opts d
 		},
 	}
 
+	// Add boost terms as should clauses
+	boolQuery := searchQuery["query"].(map[string]any)["bool"].(map[string]any)
+	if len(opts.BoostTerms) > 0 {
+		shouldClauses := []any{}
+		for term, boost := range opts.BoostTerms {
+			shouldClauses = append(shouldClauses, map[string]any{
+				"multi_match": map[string]any{
+					"query":  term,
+					"fields": []string{"title", "content"},
+					"boost":  boost,
+				},
+			})
+		}
+		boolQuery["should"] = shouldClauses
+	}
+
 	// Add filters if specified
 	var filterClauses []any
 	if len(opts.SourceIDs) > 0 {
@@ -180,7 +196,6 @@ func (s *SearchEngine) SearchDocuments(ctx context.Context, query string, opts d
 		})
 	}
 	if len(filterClauses) > 0 {
-		boolQuery := searchQuery["query"].(map[string]any)["bool"].(map[string]any)
 		boolQuery["filter"] = filterClauses
 	}
 
@@ -249,6 +264,22 @@ func (s *SearchEngine) Search(ctx context.Context, query string, queryEmbedding 
 		},
 	}
 
+	// Add boost terms as should clauses
+	boolQuery := searchQuery["query"].(map[string]any)["bool"].(map[string]any)
+	if len(opts.BoostTerms) > 0 {
+		shouldClauses := []any{}
+		for term, boost := range opts.BoostTerms {
+			shouldClauses = append(shouldClauses, map[string]any{
+				"multi_match": map[string]any{
+					"query":  term,
+					"fields": []string{"title", "content"},
+					"boost":  boost,
+				},
+			})
+		}
+		boolQuery["should"] = shouldClauses
+	}
+
 	// Add filters if specified
 	var filterClauses []any
 	if len(opts.SourceIDs) > 0 {
@@ -262,7 +293,6 @@ func (s *SearchEngine) Search(ctx context.Context, query string, queryEmbedding 
 		})
 	}
 	if len(filterClauses) > 0 {
-		boolQuery := searchQuery["query"].(map[string]any)["bool"].(map[string]any)
 		boolQuery["filter"] = filterClauses
 	}
 

--- a/internal/adapters/driven/opensearch/search_engine_test.go
+++ b/internal/adapters/driven/opensearch/search_engine_test.go
@@ -1669,6 +1669,622 @@ func TestSearchEngine_Search_WithDocumentIDFilter(t *testing.T) {
 	}
 }
 
+// TestSearchEngine_SearchDocuments_WithBoostTerms validates keyword boosting in document search
+func TestSearchEngine_SearchDocuments_WithBoostTerms(t *testing.T) {
+	tests := []struct {
+		name           string
+		query          string
+		opts           domain.SearchOptions
+		setupServer    func(*testing.T) *httptest.Server
+		wantCount      int
+		wantTotal      int
+		wantErr        bool
+		validateQuery  func(*testing.T, map[string]any)
+	}{
+		{
+			name:  "search with boost terms",
+			query: "kubernetes deployment",
+			opts: domain.SearchOptions{
+				Limit:  10,
+				Offset: 0,
+				BoostTerms: map[string]float64{
+					"helm":       2.0,
+					"production": 1.5,
+				},
+			},
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == "POST" && strings.Contains(r.URL.Path, "_search") {
+						// Parse request body
+						var reqBody map[string]any
+						if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+							t.Fatalf("Failed to decode request body: %v", err)
+						}
+
+						// Verify query structure
+						query := reqBody["query"].(map[string]any)
+						boolQuery := query["bool"].(map[string]any)
+
+						// Verify must clause exists
+						mustClauses, ok := boolQuery["must"].([]any)
+						if !ok || len(mustClauses) == 0 {
+							t.Error("Expected must clause in bool query")
+						}
+
+						// Verify should clauses for boost terms
+						shouldClauses, ok := boolQuery["should"].([]any)
+						if !ok {
+							t.Error("Expected should clauses for boost terms")
+						}
+						if len(shouldClauses) != 2 {
+							t.Errorf("Expected 2 should clauses, got %d", len(shouldClauses))
+						}
+
+						// Verify boost term structure
+						for _, clause := range shouldClauses {
+							clauseMap := clause.(map[string]any)
+							multiMatch, ok := clauseMap["multi_match"].(map[string]any)
+							if !ok {
+								t.Error("Expected multi_match in should clause")
+								continue
+							}
+
+							// Check required fields
+							if _, ok := multiMatch["query"]; !ok {
+								t.Error("Expected query in multi_match")
+							}
+							if _, ok := multiMatch["boost"]; !ok {
+								t.Error("Expected boost in multi_match")
+							}
+
+							fields, ok := multiMatch["fields"].([]any)
+							if !ok || len(fields) != 2 {
+								t.Error("Expected fields [title, content] in multi_match")
+							}
+						}
+
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]any{
+							"hits": map[string]any{
+								"total": map[string]any{"value": 1},
+								"hits": []map[string]any{
+									{
+										"_id":    "doc-1",
+										"_score": 2.5,
+										"_source": map[string]any{
+											"document_id": "doc-1",
+											"source_id":   "source-1",
+											"title":       "Kubernetes Helm Guide",
+											"content":     "Production deployment with helm",
+										},
+									},
+								},
+							},
+						})
+						return
+					}
+				}))
+			},
+			wantCount: 1,
+			wantTotal: 1,
+			wantErr:   false,
+		},
+		{
+			name:  "search without boost terms",
+			query: "kubernetes deployment",
+			opts: domain.SearchOptions{
+				Limit:  10,
+				Offset: 0,
+			},
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == "POST" && strings.Contains(r.URL.Path, "_search") {
+						var reqBody map[string]any
+						if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+							t.Fatalf("Failed to decode request body: %v", err)
+						}
+
+						query := reqBody["query"].(map[string]any)
+						boolQuery := query["bool"].(map[string]any)
+
+						// Verify NO should clauses when boost terms not specified
+						if _, ok := boolQuery["should"]; ok {
+							t.Error("Should not have should clauses when BoostTerms is empty")
+						}
+
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]any{
+							"hits": map[string]any{
+								"total": map[string]any{"value": 1},
+								"hits": []map[string]any{
+									{
+										"_id":    "doc-1",
+										"_score": 1.0,
+										"_source": map[string]any{
+											"document_id": "doc-1",
+											"source_id":   "source-1",
+											"title":       "Kubernetes Guide",
+											"content":     "Deployment guide",
+										},
+									},
+								},
+							},
+						})
+						return
+					}
+				}))
+			},
+			wantCount: 1,
+			wantTotal: 1,
+			wantErr:   false,
+		},
+		{
+			name:  "search with single boost term",
+			query: "kubernetes",
+			opts: domain.SearchOptions{
+				Limit:  10,
+				Offset: 0,
+				BoostTerms: map[string]float64{
+					"production": 3.0,
+				},
+			},
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == "POST" && strings.Contains(r.URL.Path, "_search") {
+						var reqBody map[string]any
+						if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+							t.Fatalf("Failed to decode request body: %v", err)
+						}
+
+						query := reqBody["query"].(map[string]any)
+						boolQuery := query["bool"].(map[string]any)
+
+						shouldClauses, ok := boolQuery["should"].([]any)
+						if !ok || len(shouldClauses) != 1 {
+							t.Errorf("Expected 1 should clause, got %d", len(shouldClauses))
+						}
+
+						// Verify boost value
+						clause := shouldClauses[0].(map[string]any)
+						multiMatch := clause["multi_match"].(map[string]any)
+						if multiMatch["query"] != "production" {
+							t.Errorf("Expected query 'production', got %v", multiMatch["query"])
+						}
+						if multiMatch["boost"].(float64) != 3.0 {
+							t.Errorf("Expected boost 3.0, got %v", multiMatch["boost"])
+						}
+
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]any{
+							"hits": map[string]any{
+								"total": map[string]any{"value": 1},
+								"hits":  []map[string]any{},
+							},
+						})
+						return
+					}
+				}))
+			},
+			wantCount: 0,
+			wantTotal: 1,
+			wantErr:   false,
+		},
+		{
+			name:  "search with boost terms and filters",
+			query: "kubernetes",
+			opts: domain.SearchOptions{
+				Limit:     10,
+				Offset:    0,
+				SourceIDs: []string{"source-1"},
+				BoostTerms: map[string]float64{
+					"helm": 2.0,
+				},
+			},
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == "POST" && strings.Contains(r.URL.Path, "_search") {
+						var reqBody map[string]any
+						if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+							t.Fatalf("Failed to decode request body: %v", err)
+						}
+
+						query := reqBody["query"].(map[string]any)
+						boolQuery := query["bool"].(map[string]any)
+
+						// Verify both should and filter clauses exist
+						if _, ok := boolQuery["should"]; !ok {
+							t.Error("Expected should clause for boost terms")
+						}
+						if _, ok := boolQuery["filter"]; !ok {
+							t.Error("Expected filter clause for source IDs")
+						}
+
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]any{
+							"hits": map[string]any{
+								"total": map[string]any{"value": 1},
+								"hits":  []map[string]any{},
+							},
+						})
+						return
+					}
+				}))
+			},
+			wantCount: 0,
+			wantTotal: 1,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := tt.setupServer(t)
+			defer ts.Close()
+
+			cfg := Config{
+				URL:       ts.URL,
+				IndexName: "sercha_chunks",
+				Timeout:   5 * time.Second,
+			}
+
+			engine, err := NewSearchEngine(cfg)
+			if err != nil {
+				t.Fatalf("NewSearchEngine() error = %v", err)
+			}
+
+			results, total, err := engine.SearchDocuments(context.Background(), tt.query, tt.opts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SearchDocuments() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if len(results) != tt.wantCount {
+					t.Errorf("SearchDocuments() returned %d results, want %d", len(results), tt.wantCount)
+				}
+				if total != tt.wantTotal {
+					t.Errorf("SearchDocuments() total = %d, want %d", total, tt.wantTotal)
+				}
+			}
+		})
+	}
+}
+
+// TestSearchEngine_Search_WithBoostTerms validates keyword boosting in chunk search
+func TestSearchEngine_Search_WithBoostTerms(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		opts        domain.SearchOptions
+		setupServer func(*testing.T) *httptest.Server
+		wantCount   int
+		wantTotal   int
+		wantErr     bool
+	}{
+		{
+			name:  "chunk search with boost terms",
+			query: "kubernetes deployment",
+			opts: domain.SearchOptions{
+				Limit:  10,
+				Offset: 0,
+				BoostTerms: map[string]float64{
+					"helm":       2.0,
+					"production": 1.5,
+				},
+			},
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == "POST" && strings.Contains(r.URL.Path, "_search") {
+						var reqBody map[string]any
+						if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+							t.Fatalf("Failed to decode request body: %v", err)
+						}
+
+						query := reqBody["query"].(map[string]any)
+						boolQuery := query["bool"].(map[string]any)
+
+						// Verify should clauses exist
+						shouldClauses, ok := boolQuery["should"].([]any)
+						if !ok || len(shouldClauses) != 2 {
+							t.Errorf("Expected 2 should clauses, got %d", len(shouldClauses))
+						}
+
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]any{
+							"hits": map[string]any{
+								"total": map[string]any{"value": 2},
+								"hits": []map[string]any{
+									{
+										"_id":    "chunk-1",
+										"_score": 2.5,
+										"_source": map[string]any{
+											"id":             "chunk-1",
+											"document_id":    "doc-1",
+											"source_id":      "source-1",
+											"content":        "Kubernetes deployment with helm",
+											"chunk_position": 0,
+										},
+									},
+									{
+										"_id":    "chunk-2",
+										"_score": 2.0,
+										"_source": map[string]any{
+											"id":             "chunk-2",
+											"document_id":    "doc-1",
+											"source_id":      "source-1",
+											"content":        "Production kubernetes setup",
+											"chunk_position": 1,
+										},
+									},
+								},
+							},
+						})
+						return
+					}
+				}))
+			},
+			wantCount: 2,
+			wantTotal: 2,
+			wantErr:   false,
+		},
+		{
+			name:  "chunk search without boost terms",
+			query: "kubernetes",
+			opts: domain.SearchOptions{
+				Limit:  10,
+				Offset: 0,
+			},
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == "POST" && strings.Contains(r.URL.Path, "_search") {
+						var reqBody map[string]any
+						if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+							t.Fatalf("Failed to decode request body: %v", err)
+						}
+
+						query := reqBody["query"].(map[string]any)
+						boolQuery := query["bool"].(map[string]any)
+
+						// Verify NO should clauses
+						if _, ok := boolQuery["should"]; ok {
+							t.Error("Should not have should clauses when BoostTerms is empty")
+						}
+
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]any{
+							"hits": map[string]any{
+								"total": map[string]any{"value": 1},
+								"hits": []map[string]any{
+									{
+										"_id":    "chunk-1",
+										"_score": 1.0,
+										"_source": map[string]any{
+											"id":             "chunk-1",
+											"document_id":    "doc-1",
+											"source_id":      "source-1",
+											"content":        "Kubernetes content",
+											"chunk_position": 0,
+										},
+									},
+								},
+							},
+						})
+						return
+					}
+				}))
+			},
+			wantCount: 1,
+			wantTotal: 1,
+			wantErr:   false,
+		},
+		{
+			name:  "chunk search with empty boost terms map",
+			query: "test",
+			opts: domain.SearchOptions{
+				Limit:      10,
+				Offset:     0,
+				BoostTerms: map[string]float64{},
+			},
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == "POST" && strings.Contains(r.URL.Path, "_search") {
+						var reqBody map[string]any
+						if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+							t.Fatalf("Failed to decode request body: %v", err)
+						}
+
+						query := reqBody["query"].(map[string]any)
+						boolQuery := query["bool"].(map[string]any)
+
+						// Empty map should not add should clauses
+						if _, ok := boolQuery["should"]; ok {
+							t.Error("Should not have should clauses when BoostTerms map is empty")
+						}
+
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]any{
+							"hits": map[string]any{
+								"total": map[string]any{"value": 0},
+								"hits":  []map[string]any{},
+							},
+						})
+						return
+					}
+				}))
+			},
+			wantCount: 0,
+			wantTotal: 0,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := tt.setupServer(t)
+			defer ts.Close()
+
+			cfg := Config{
+				URL:       ts.URL,
+				IndexName: "sercha_chunks",
+				Timeout:   5 * time.Second,
+			}
+
+			engine, err := NewSearchEngine(cfg)
+			if err != nil {
+				t.Fatalf("NewSearchEngine() error = %v", err)
+			}
+
+			results, total, err := engine.Search(context.Background(), tt.query, nil, tt.opts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Search() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if len(results) != tt.wantCount {
+					t.Errorf("Search() returned %d results, want %d", len(results), tt.wantCount)
+				}
+				if total != tt.wantTotal {
+					t.Errorf("Search() total = %d, want %d", total, tt.wantTotal)
+				}
+			}
+		})
+	}
+}
+
+// TestSearchEngine_BoostTermsQueryStructure validates exact OpenSearch query structure
+func TestSearchEngine_BoostTermsQueryStructure(t *testing.T) {
+	tests := []struct {
+		name            string
+		boostTerms      map[string]float64
+		validateRequest func(*testing.T, map[string]any)
+	}{
+		{
+			name: "multiple boost terms create multiple should clauses",
+			boostTerms: map[string]float64{
+				"kubernetes": 2.0,
+				"helm":       1.5,
+				"docker":     1.2,
+			},
+			validateRequest: func(t *testing.T, reqBody map[string]any) {
+				query := reqBody["query"].(map[string]any)
+				boolQuery := query["bool"].(map[string]any)
+				shouldClauses := boolQuery["should"].([]any)
+
+				if len(shouldClauses) != 3 {
+					t.Errorf("Expected 3 should clauses, got %d", len(shouldClauses))
+				}
+
+				// Verify each should clause has correct structure
+				foundTerms := make(map[string]float64)
+				for _, clause := range shouldClauses {
+					clauseMap := clause.(map[string]any)
+					multiMatch := clauseMap["multi_match"].(map[string]any)
+
+					term := multiMatch["query"].(string)
+					boost := multiMatch["boost"].(float64)
+					foundTerms[term] = boost
+
+					// Verify fields
+					fields := multiMatch["fields"].([]any)
+					if len(fields) != 2 {
+						t.Errorf("Expected 2 fields, got %d", len(fields))
+					}
+					if fields[0] != "title" || fields[1] != "content" {
+						t.Errorf("Expected fields [title, content], got %v", fields)
+					}
+				}
+
+				// Verify all boost terms are present with correct values
+				for term, expectedBoost := range map[string]float64{
+					"kubernetes": 2.0,
+					"helm":       1.5,
+					"docker":     1.2,
+				} {
+					if actualBoost, ok := foundTerms[term]; !ok {
+						t.Errorf("Missing boost term %q in query", term)
+					} else if actualBoost != expectedBoost {
+						t.Errorf("Boost for %q = %v, want %v", term, actualBoost, expectedBoost)
+					}
+				}
+			},
+		},
+		{
+			name: "fractional boost values are preserved",
+			boostTerms: map[string]float64{
+				"important": 1.25,
+				"critical":  2.75,
+			},
+			validateRequest: func(t *testing.T, reqBody map[string]any) {
+				query := reqBody["query"].(map[string]any)
+				boolQuery := query["bool"].(map[string]any)
+				shouldClauses := boolQuery["should"].([]any)
+
+				for _, clause := range shouldClauses {
+					clauseMap := clause.(map[string]any)
+					multiMatch := clauseMap["multi_match"].(map[string]any)
+					term := multiMatch["query"].(string)
+					boost := multiMatch["boost"].(float64)
+
+					if term == "important" && boost != 1.25 {
+						t.Errorf("Boost for important = %v, want 1.25", boost)
+					}
+					if term == "critical" && boost != 2.75 {
+						t.Errorf("Boost for critical = %v, want 2.75", boost)
+					}
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == "POST" && strings.Contains(r.URL.Path, "_search") {
+					var reqBody map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+						t.Fatalf("Failed to decode request body: %v", err)
+					}
+
+					tt.validateRequest(t, reqBody)
+
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"hits": map[string]any{
+							"total": map[string]any{"value": 0},
+							"hits":  []map[string]any{},
+						},
+					})
+					return
+				}
+			}))
+			defer ts.Close()
+
+			cfg := Config{
+				URL:       ts.URL,
+				IndexName: "sercha_chunks",
+				Timeout:   5 * time.Second,
+			}
+
+			engine, err := NewSearchEngine(cfg)
+			if err != nil {
+				t.Fatalf("NewSearchEngine() error = %v", err)
+			}
+
+			opts := domain.SearchOptions{
+				Limit:      10,
+				Offset:     0,
+				BoostTerms: tt.boostTerms,
+			}
+
+			_, _, err = engine.SearchDocuments(context.Background(), "test query", opts)
+			if err != nil {
+				t.Errorf("SearchDocuments() error = %v", err)
+			}
+		})
+	}
+}
+
 // TestSearchEngine_InterfaceCompliance validates interface implementation
 func TestSearchEngine_InterfaceCompliance(t *testing.T) {
 	// This test verifies that SearchEngine implements the driven.SearchEngine interface

--- a/internal/adapters/driven/postgres/schema.sql
+++ b/internal/adapters/driven/postgres/schema.sql
@@ -406,3 +406,26 @@ CREATE INDEX IF NOT EXISTS idx_oauth_refresh_tokens_access ON oauth_refresh_toke
 CREATE INDEX IF NOT EXISTS idx_oauth_refresh_tokens_client ON oauth_refresh_tokens(client_id);
 CREATE INDEX IF NOT EXISTS idx_oauth_refresh_tokens_user ON oauth_refresh_tokens(user_id);
 CREATE INDEX IF NOT EXISTS idx_oauth_refresh_tokens_expires ON oauth_refresh_tokens(expires_at);
+
+-- Sync events table (for audit logging)
+CREATE TABLE IF NOT EXISTS sync_events (
+    id TEXT PRIMARY KEY,
+    team_id TEXT NOT NULL,
+    source_id TEXT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    source_name TEXT,
+    provider_type TEXT,
+    status TEXT NOT NULL,
+    documents_added INT NOT NULL DEFAULT 0,
+    documents_updated INT NOT NULL DEFAULT 0,
+    documents_deleted INT NOT NULL DEFAULT 0,
+    chunks_indexed INT NOT NULL DEFAULT 0,
+    error_count INT NOT NULL DEFAULT 0,
+    error_message TEXT,
+    duration_seconds DECIMAL(10,2),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_events_team_id ON sync_events(team_id);
+CREATE INDEX IF NOT EXISTS idx_sync_events_source_id ON sync_events(source_id);
+CREATE INDEX IF NOT EXISTS idx_sync_events_created_at ON sync_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_sync_events_team_created ON sync_events(team_id, created_at DESC);

--- a/internal/adapters/driven/postgres/sync_event.go
+++ b/internal/adapters/driven/postgres/sync_event.go
@@ -1,0 +1,189 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/sercha-oss/sercha-core/internal/core/domain"
+	"github.com/sercha-oss/sercha-core/internal/core/ports/driven"
+)
+
+// Verify interface compliance
+var _ driven.SyncEventRepository = (*SyncEventRepository)(nil)
+
+// SyncEventRepository implements driven.SyncEventRepository using PostgreSQL
+type SyncEventRepository struct {
+	db *DB
+}
+
+// NewSyncEventRepository creates a new SyncEventRepository
+func NewSyncEventRepository(db *DB) *SyncEventRepository {
+	return &SyncEventRepository{db: db}
+}
+
+// Save logs a sync event for audit tracking
+func (r *SyncEventRepository) Save(ctx context.Context, event *domain.SyncEvent) error {
+	q := `
+		INSERT INTO sync_events (
+			id, team_id, source_id, source_name, provider_type, status,
+			documents_added, documents_updated, documents_deleted,
+			chunks_indexed, error_count, error_message, duration_seconds,
+			created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+	`
+
+	_, err := r.db.ExecContext(ctx, q,
+		event.ID,
+		event.TeamID,
+		event.SourceID,
+		event.SourceName,
+		string(event.ProviderType),
+		string(event.Status),
+		event.DocumentsAdded,
+		event.DocumentsUpdated,
+		event.DocumentsDeleted,
+		event.ChunksIndexed,
+		event.ErrorCount,
+		event.ErrorMessage,
+		event.DurationSeconds,
+		event.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert sync event: %w", err)
+	}
+
+	return nil
+}
+
+// List retrieves recent sync events for a team
+func (r *SyncEventRepository) List(ctx context.Context, teamID string, limit int) ([]*domain.SyncEvent, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 50
+	}
+
+	q := `
+		SELECT id, team_id, source_id, source_name, provider_type, status,
+		       documents_added, documents_updated, documents_deleted,
+		       chunks_indexed, error_count, error_message, duration_seconds,
+		       created_at
+		FROM sync_events
+		WHERE team_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2
+	`
+
+	rows, err := r.db.QueryContext(ctx, q, teamID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query sync events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var events []*domain.SyncEvent
+	for rows.Next() {
+		var se domain.SyncEvent
+		var providerType string
+		var status string
+		var errorMessage sql.NullString
+
+		err := rows.Scan(
+			&se.ID,
+			&se.TeamID,
+			&se.SourceID,
+			&se.SourceName,
+			&providerType,
+			&status,
+			&se.DocumentsAdded,
+			&se.DocumentsUpdated,
+			&se.DocumentsDeleted,
+			&se.ChunksIndexed,
+			&se.ErrorCount,
+			&errorMessage,
+			&se.DurationSeconds,
+			&se.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scan sync event: %w", err)
+		}
+
+		se.ProviderType = domain.ProviderType(providerType)
+		se.Status = domain.SyncStatus(status)
+		if errorMessage.Valid {
+			se.ErrorMessage = errorMessage.String
+		}
+
+		events = append(events, &se)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sync events: %w", err)
+	}
+
+	return events, nil
+}
+
+// ListBySource retrieves recent sync events for a specific source
+func (r *SyncEventRepository) ListBySource(ctx context.Context, sourceID string, limit int) ([]*domain.SyncEvent, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 50
+	}
+
+	q := `
+		SELECT id, team_id, source_id, source_name, provider_type, status,
+		       documents_added, documents_updated, documents_deleted,
+		       chunks_indexed, error_count, error_message, duration_seconds,
+		       created_at
+		FROM sync_events
+		WHERE source_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2
+	`
+
+	rows, err := r.db.QueryContext(ctx, q, sourceID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query sync events by source: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var events []*domain.SyncEvent
+	for rows.Next() {
+		var se domain.SyncEvent
+		var providerType string
+		var status string
+		var errorMessage sql.NullString
+
+		err := rows.Scan(
+			&se.ID,
+			&se.TeamID,
+			&se.SourceID,
+			&se.SourceName,
+			&providerType,
+			&status,
+			&se.DocumentsAdded,
+			&se.DocumentsUpdated,
+			&se.DocumentsDeleted,
+			&se.ChunksIndexed,
+			&se.ErrorCount,
+			&errorMessage,
+			&se.DurationSeconds,
+			&se.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scan sync event: %w", err)
+		}
+
+		se.ProviderType = domain.ProviderType(providerType)
+		se.Status = domain.SyncStatus(status)
+		if errorMessage.Valid {
+			se.ErrorMessage = errorMessage.String
+		}
+
+		events = append(events, &se)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sync events by source: %w", err)
+	}
+
+	return events, nil
+}

--- a/internal/adapters/driven/postgres/sync_event_test.go
+++ b/internal/adapters/driven/postgres/sync_event_test.go
@@ -1,0 +1,782 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/sercha-oss/sercha-core/internal/core/domain"
+)
+
+// TestSyncEventRepository_Save_Success tests successful save of a sync event
+func TestSyncEventRepository_Save_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	event := &domain.SyncEvent{
+		ID:               "evt-123",
+		TeamID:           "team-456",
+		SourceID:         "src-789",
+		SourceName:       "Test Source",
+		ProviderType:     domain.ProviderTypeGitHub,
+		Status:           domain.SyncStatusCompleted,
+		DocumentsAdded:   10,
+		DocumentsUpdated: 5,
+		DocumentsDeleted: 2,
+		ChunksIndexed:    100,
+		ErrorCount:       0,
+		ErrorMessage:     "",
+		DurationSeconds:  45.5,
+		CreatedAt:        time.Now(),
+	}
+
+	mock.ExpectExec(`INSERT INTO sync_events`).
+		WithArgs(
+			event.ID,
+			event.TeamID,
+			event.SourceID,
+			event.SourceName,
+			string(event.ProviderType),
+			string(event.Status),
+			event.DocumentsAdded,
+			event.DocumentsUpdated,
+			event.DocumentsDeleted,
+			event.ChunksIndexed,
+			event.ErrorCount,
+			event.ErrorMessage,
+			event.DurationSeconds,
+			event.CreatedAt,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Save(context.Background(), event)
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_Save_WithError tests saving a failed sync event with error message
+func TestSyncEventRepository_Save_WithError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	event := &domain.SyncEvent{
+		ID:               "evt-fail-123",
+		TeamID:           "team-456",
+		SourceID:         "src-789",
+		SourceName:       "Failed Source",
+		ProviderType:     domain.ProviderTypeNotion,
+		Status:           domain.SyncStatusFailed,
+		DocumentsAdded:   3,
+		DocumentsUpdated: 1,
+		DocumentsDeleted: 0,
+		ChunksIndexed:    20,
+		ErrorCount:       5,
+		ErrorMessage:     "authentication token expired",
+		DurationSeconds:  10.2,
+		CreatedAt:        time.Now(),
+	}
+
+	mock.ExpectExec(`INSERT INTO sync_events`).
+		WithArgs(
+			event.ID,
+			event.TeamID,
+			event.SourceID,
+			event.SourceName,
+			string(event.ProviderType),
+			string(event.Status),
+			event.DocumentsAdded,
+			event.DocumentsUpdated,
+			event.DocumentsDeleted,
+			event.ChunksIndexed,
+			event.ErrorCount,
+			event.ErrorMessage,
+			event.DurationSeconds,
+			event.CreatedAt,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Save(context.Background(), event)
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_Save_DatabaseError tests error handling for save failures
+func TestSyncEventRepository_Save_DatabaseError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	event := &domain.SyncEvent{
+		ID:               "evt-123",
+		TeamID:           "team-456",
+		SourceID:         "src-789",
+		SourceName:       "Test Source",
+		ProviderType:     domain.ProviderTypeGitHub,
+		Status:           domain.SyncStatusCompleted,
+		DocumentsAdded:   10,
+		DocumentsUpdated: 5,
+		DocumentsDeleted: 2,
+		ChunksIndexed:    100,
+		ErrorCount:       0,
+		ErrorMessage:     "",
+		DurationSeconds:  45.5,
+		CreatedAt:        time.Now(),
+	}
+
+	expectedErr := errors.New("database connection error")
+
+	mock.ExpectExec(`INSERT INTO sync_events`).
+		WithArgs(
+			event.ID,
+			event.TeamID,
+			event.SourceID,
+			event.SourceName,
+			string(event.ProviderType),
+			string(event.Status),
+			event.DocumentsAdded,
+			event.DocumentsUpdated,
+			event.DocumentsDeleted,
+			event.ChunksIndexed,
+			event.ErrorCount,
+			event.ErrorMessage,
+			event.DurationSeconds,
+			event.CreatedAt,
+		).
+		WillReturnError(expectedErr)
+
+	err = repo.Save(context.Background(), event)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_List_Success tests successful retrieval of sync events by team
+func TestSyncEventRepository_List_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	teamID := "team-123"
+	limit := 10
+	createdAt1 := time.Now().Add(-time.Hour)
+	createdAt2 := time.Now().Add(-2 * time.Hour)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "source_id", "source_name", "provider_type", "status",
+		"documents_added", "documents_updated", "documents_deleted",
+		"chunks_indexed", "error_count", "error_message", "duration_seconds",
+		"created_at",
+	}).
+		AddRow("evt-1", teamID, "src-1", "Source 1", "github", "completed",
+			10, 5, 2, 100, 0, nil, 45.5, createdAt1).
+		AddRow("evt-2", teamID, "src-2", "Source 2", "notion", "failed",
+			3, 1, 0, 20, 5, "auth error", 10.2, createdAt2)
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(teamID, limit).
+		WillReturnRows(rows)
+
+	events, err := repo.List(context.Background(), teamID, limit)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	// Verify first event
+	if events[0].ID != "evt-1" {
+		t.Errorf("events[0].ID = %q, want %q", events[0].ID, "evt-1")
+	}
+	if events[0].TeamID != teamID {
+		t.Errorf("events[0].TeamID = %q, want %q", events[0].TeamID, teamID)
+	}
+	if events[0].SourceID != "src-1" {
+		t.Errorf("events[0].SourceID = %q, want %q", events[0].SourceID, "src-1")
+	}
+	if events[0].SourceName != "Source 1" {
+		t.Errorf("events[0].SourceName = %q, want %q", events[0].SourceName, "Source 1")
+	}
+	if events[0].ProviderType != domain.ProviderTypeGitHub {
+		t.Errorf("events[0].ProviderType = %q, want %q", events[0].ProviderType, domain.ProviderTypeGitHub)
+	}
+	if events[0].Status != domain.SyncStatusCompleted {
+		t.Errorf("events[0].Status = %q, want %q", events[0].Status, domain.SyncStatusCompleted)
+	}
+	if events[0].DocumentsAdded != 10 {
+		t.Errorf("events[0].DocumentsAdded = %d, want 10", events[0].DocumentsAdded)
+	}
+	if events[0].ErrorMessage != "" {
+		t.Errorf("events[0].ErrorMessage = %q, want empty", events[0].ErrorMessage)
+	}
+
+	// Verify second event
+	if events[1].ID != "evt-2" {
+		t.Errorf("events[1].ID = %q, want %q", events[1].ID, "evt-2")
+	}
+	if events[1].Status != domain.SyncStatusFailed {
+		t.Errorf("events[1].Status = %q, want %q", events[1].Status, domain.SyncStatusFailed)
+	}
+	if events[1].ErrorCount != 5 {
+		t.Errorf("events[1].ErrorCount = %d, want 5", events[1].ErrorCount)
+	}
+	if events[1].ErrorMessage != "auth error" {
+		t.Errorf("events[1].ErrorMessage = %q, want %q", events[1].ErrorMessage, "auth error")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_List_Empty tests retrieval with no events
+func TestSyncEventRepository_List_Empty(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	teamID := "team-no-events"
+	limit := 10
+
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "source_id", "source_name", "provider_type", "status",
+		"documents_added", "documents_updated", "documents_deleted",
+		"chunks_indexed", "error_count", "error_message", "duration_seconds",
+		"created_at",
+	})
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(teamID, limit).
+		WillReturnRows(rows)
+
+	events, err := repo.List(context.Background(), teamID, limit)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	if len(events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(events))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_List_LimitClamping tests that invalid limits are clamped
+func TestSyncEventRepository_List_LimitClamping(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputLimit    int
+		expectedLimit int
+	}{
+		{
+			name:          "zero limit defaults to 50",
+			inputLimit:    0,
+			expectedLimit: 50,
+		},
+		{
+			name:          "negative limit defaults to 50",
+			inputLimit:    -10,
+			expectedLimit: 50,
+		},
+		{
+			name:          "limit over 100 clamped to 50",
+			inputLimit:    150,
+			expectedLimit: 50,
+		},
+		{
+			name:          "valid limit preserved",
+			inputLimit:    25,
+			expectedLimit: 25,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("failed to create mock db: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			repo := NewSyncEventRepository(&DB{DB: db})
+
+			rows := sqlmock.NewRows([]string{
+				"id", "team_id", "source_id", "source_name", "provider_type", "status",
+				"documents_added", "documents_updated", "documents_deleted",
+				"chunks_indexed", "error_count", "error_message", "duration_seconds",
+				"created_at",
+			})
+
+			mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+				WithArgs("team-123", tt.expectedLimit).
+				WillReturnRows(rows)
+
+			_, err = repo.List(context.Background(), "team-123", tt.inputLimit)
+			if err != nil {
+				t.Fatalf("List failed: %v", err)
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unfulfilled expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestSyncEventRepository_List_DatabaseError tests error handling for query failures
+func TestSyncEventRepository_List_DatabaseError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	teamID := "team-123"
+	limit := 10
+	expectedErr := errors.New("database connection error")
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(teamID, limit).
+		WillReturnError(expectedErr)
+
+	events, err := repo.List(context.Background(), teamID, limit)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if events != nil {
+		t.Errorf("expected nil events on error, got %v", events)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_List_ScanError tests error handling for row scan failures
+func TestSyncEventRepository_List_ScanError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	teamID := "team-123"
+	limit := 10
+
+	// Return invalid data that will fail to scan
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "source_id", "source_name", "provider_type", "status",
+		"documents_added", "documents_updated", "documents_deleted",
+		"chunks_indexed", "error_count", "error_message", "duration_seconds",
+		"created_at",
+	}).
+		AddRow("evt-1", teamID, "src-1", "Source 1", "github", "completed",
+			"INVALID", 5, 2, 100, 0, nil, 45.5, time.Now()) // documents_added is string instead of int
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(teamID, limit).
+		WillReturnRows(rows)
+
+	events, err := repo.List(context.Background(), teamID, limit)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if events != nil {
+		t.Errorf("expected nil events on error, got %v", events)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_ListBySource_Success tests successful retrieval of sync events by source
+func TestSyncEventRepository_ListBySource_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	sourceID := "src-123"
+	limit := 5
+	createdAt1 := time.Now().Add(-time.Hour)
+	createdAt2 := time.Now().Add(-2 * time.Hour)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "source_id", "source_name", "provider_type", "status",
+		"documents_added", "documents_updated", "documents_deleted",
+		"chunks_indexed", "error_count", "error_message", "duration_seconds",
+		"created_at",
+	}).
+		AddRow("evt-1", "team-1", sourceID, "My Source", "github", "completed",
+			15, 8, 3, 150, 0, nil, 60.0, createdAt1).
+		AddRow("evt-2", "team-1", sourceID, "My Source", "github", "completed",
+			5, 2, 1, 50, 0, nil, 30.5, createdAt2)
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(sourceID, limit).
+		WillReturnRows(rows)
+
+	events, err := repo.ListBySource(context.Background(), sourceID, limit)
+	if err != nil {
+		t.Fatalf("ListBySource failed: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	// Verify both events have the same source ID
+	for i, event := range events {
+		if event.SourceID != sourceID {
+			t.Errorf("events[%d].SourceID = %q, want %q", i, event.SourceID, sourceID)
+		}
+	}
+
+	// Verify first event details
+	if events[0].ID != "evt-1" {
+		t.Errorf("events[0].ID = %q, want %q", events[0].ID, "evt-1")
+	}
+	if events[0].DocumentsAdded != 15 {
+		t.Errorf("events[0].DocumentsAdded = %d, want 15", events[0].DocumentsAdded)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_ListBySource_Empty tests retrieval with no events for source
+func TestSyncEventRepository_ListBySource_Empty(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	sourceID := "src-no-events"
+	limit := 10
+
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "source_id", "source_name", "provider_type", "status",
+		"documents_added", "documents_updated", "documents_deleted",
+		"chunks_indexed", "error_count", "error_message", "duration_seconds",
+		"created_at",
+	})
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(sourceID, limit).
+		WillReturnRows(rows)
+
+	events, err := repo.ListBySource(context.Background(), sourceID, limit)
+	if err != nil {
+		t.Fatalf("ListBySource failed: %v", err)
+	}
+
+	if len(events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(events))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_ListBySource_LimitClamping tests that invalid limits are clamped
+func TestSyncEventRepository_ListBySource_LimitClamping(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputLimit    int
+		expectedLimit int
+	}{
+		{
+			name:          "zero limit defaults to 50",
+			inputLimit:    0,
+			expectedLimit: 50,
+		},
+		{
+			name:          "negative limit defaults to 50",
+			inputLimit:    -5,
+			expectedLimit: 50,
+		},
+		{
+			name:          "limit over 100 clamped to 50",
+			inputLimit:    200,
+			expectedLimit: 50,
+		},
+		{
+			name:          "valid limit preserved",
+			inputLimit:    30,
+			expectedLimit: 30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("failed to create mock db: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			repo := NewSyncEventRepository(&DB{DB: db})
+
+			rows := sqlmock.NewRows([]string{
+				"id", "team_id", "source_id", "source_name", "provider_type", "status",
+				"documents_added", "documents_updated", "documents_deleted",
+				"chunks_indexed", "error_count", "error_message", "duration_seconds",
+				"created_at",
+			})
+
+			mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+				WithArgs("src-123", tt.expectedLimit).
+				WillReturnRows(rows)
+
+			_, err = repo.ListBySource(context.Background(), "src-123", tt.inputLimit)
+			if err != nil {
+				t.Fatalf("ListBySource failed: %v", err)
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unfulfilled expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestSyncEventRepository_ListBySource_DatabaseError tests error handling for query failures
+func TestSyncEventRepository_ListBySource_DatabaseError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	sourceID := "src-123"
+	limit := 10
+	expectedErr := errors.New("database timeout")
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(sourceID, limit).
+		WillReturnError(expectedErr)
+
+	events, err := repo.ListBySource(context.Background(), sourceID, limit)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if events != nil {
+		t.Errorf("expected nil events on error, got %v", events)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestSyncEventRepository_InterfaceCompliance verifies the repository implements the interface
+func TestSyncEventRepository_InterfaceCompliance(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// This will fail to compile if the interface is not properly implemented
+	repo := NewSyncEventRepository(&DB{DB: db})
+	if repo == nil {
+		t.Fatal("expected non-nil repository")
+	}
+}
+
+// TestSyncEventRepository_RoundTrip tests saving and retrieving sync events
+func TestSyncEventRepository_RoundTrip(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	repo := NewSyncEventRepository(&DB{DB: db})
+
+	originalEvent := &domain.SyncEvent{
+		ID:               "evt-roundtrip",
+		TeamID:           "team-rt",
+		SourceID:         "src-rt",
+		SourceName:       "RoundTrip Source",
+		ProviderType:     domain.ProviderTypeGitHub,
+		Status:           domain.SyncStatusCompleted,
+		DocumentsAdded:   25,
+		DocumentsUpdated: 15,
+		DocumentsDeleted: 5,
+		ChunksIndexed:    300,
+		ErrorCount:       0,
+		ErrorMessage:     "",
+		DurationSeconds:  90.5,
+		CreatedAt:        time.Now().Truncate(time.Microsecond), // Postgres precision
+	}
+
+	// Mock save
+	mock.ExpectExec(`INSERT INTO sync_events`).
+		WithArgs(
+			originalEvent.ID,
+			originalEvent.TeamID,
+			originalEvent.SourceID,
+			originalEvent.SourceName,
+			string(originalEvent.ProviderType),
+			string(originalEvent.Status),
+			originalEvent.DocumentsAdded,
+			originalEvent.DocumentsUpdated,
+			originalEvent.DocumentsDeleted,
+			originalEvent.ChunksIndexed,
+			originalEvent.ErrorCount,
+			originalEvent.ErrorMessage,
+			originalEvent.DurationSeconds,
+			originalEvent.CreatedAt,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Save(context.Background(), originalEvent)
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Mock retrieve by team
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "source_id", "source_name", "provider_type", "status",
+		"documents_added", "documents_updated", "documents_deleted",
+		"chunks_indexed", "error_count", "error_message", "duration_seconds",
+		"created_at",
+	}).
+		AddRow(
+			originalEvent.ID,
+			originalEvent.TeamID,
+			originalEvent.SourceID,
+			originalEvent.SourceName,
+			string(originalEvent.ProviderType),
+			string(originalEvent.Status),
+			originalEvent.DocumentsAdded,
+			originalEvent.DocumentsUpdated,
+			originalEvent.DocumentsDeleted,
+			originalEvent.ChunksIndexed,
+			originalEvent.ErrorCount,
+			sql.NullString{}, // Empty error message
+			originalEvent.DurationSeconds,
+			originalEvent.CreatedAt,
+		)
+
+	mock.ExpectQuery(`SELECT id, team_id, source_id, source_name, provider_type, status`).
+		WithArgs(originalEvent.TeamID, 50).
+		WillReturnRows(rows)
+
+	events, err := repo.List(context.Background(), originalEvent.TeamID, 50)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	retrievedEvent := events[0]
+
+	// Verify all fields match
+	if retrievedEvent.ID != originalEvent.ID {
+		t.Errorf("ID = %q, want %q", retrievedEvent.ID, originalEvent.ID)
+	}
+	if retrievedEvent.TeamID != originalEvent.TeamID {
+		t.Errorf("TeamID = %q, want %q", retrievedEvent.TeamID, originalEvent.TeamID)
+	}
+	if retrievedEvent.SourceID != originalEvent.SourceID {
+		t.Errorf("SourceID = %q, want %q", retrievedEvent.SourceID, originalEvent.SourceID)
+	}
+	if retrievedEvent.SourceName != originalEvent.SourceName {
+		t.Errorf("SourceName = %q, want %q", retrievedEvent.SourceName, originalEvent.SourceName)
+	}
+	if retrievedEvent.ProviderType != originalEvent.ProviderType {
+		t.Errorf("ProviderType = %q, want %q", retrievedEvent.ProviderType, originalEvent.ProviderType)
+	}
+	if retrievedEvent.Status != originalEvent.Status {
+		t.Errorf("Status = %q, want %q", retrievedEvent.Status, originalEvent.Status)
+	}
+	if retrievedEvent.DocumentsAdded != originalEvent.DocumentsAdded {
+		t.Errorf("DocumentsAdded = %d, want %d", retrievedEvent.DocumentsAdded, originalEvent.DocumentsAdded)
+	}
+	if retrievedEvent.DocumentsUpdated != originalEvent.DocumentsUpdated {
+		t.Errorf("DocumentsUpdated = %d, want %d", retrievedEvent.DocumentsUpdated, originalEvent.DocumentsUpdated)
+	}
+	if retrievedEvent.DocumentsDeleted != originalEvent.DocumentsDeleted {
+		t.Errorf("DocumentsDeleted = %d, want %d", retrievedEvent.DocumentsDeleted, originalEvent.DocumentsDeleted)
+	}
+	if retrievedEvent.ChunksIndexed != originalEvent.ChunksIndexed {
+		t.Errorf("ChunksIndexed = %d, want %d", retrievedEvent.ChunksIndexed, originalEvent.ChunksIndexed)
+	}
+	if retrievedEvent.ErrorCount != originalEvent.ErrorCount {
+		t.Errorf("ErrorCount = %d, want %d", retrievedEvent.ErrorCount, originalEvent.ErrorCount)
+	}
+	if retrievedEvent.ErrorMessage != originalEvent.ErrorMessage {
+		t.Errorf("ErrorMessage = %q, want %q", retrievedEvent.ErrorMessage, originalEvent.ErrorMessage)
+	}
+	if retrievedEvent.DurationSeconds != originalEvent.DurationSeconds {
+		t.Errorf("DurationSeconds = %f, want %f", retrievedEvent.DurationSeconds, originalEvent.DurationSeconds)
+	}
+	if !retrievedEvent.CreatedAt.Equal(originalEvent.CreatedAt) {
+		t.Errorf("CreatedAt = %v, want %v", retrievedEvent.CreatedAt, originalEvent.CreatedAt)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}

--- a/internal/adapters/driving/http/handlers.go
+++ b/internal/adapters/driving/http/handlers.go
@@ -631,11 +631,12 @@ func (s *Server) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
 // SearchRequest represents a search query request
 // @Description Search query request
 type searchRequest struct {
-	Query     string            `json:"query" example:"how to configure authentication"`
-	Mode      domain.SearchMode `json:"mode,omitempty" example:"hybrid" enums:"hybrid,text,semantic"`
-	Limit     int               `json:"limit,omitempty" example:"20"`
-	Offset    int               `json:"offset,omitempty" example:"0"`
-	SourceIDs []string          `json:"source_ids,omitempty"`
+	Query      string             `json:"query" example:"how to configure authentication"`
+	Mode       domain.SearchMode  `json:"mode,omitempty" example:"hybrid" enums:"hybrid,text,semantic"`
+	Limit      int                `json:"limit,omitempty" example:"20"`
+	Offset     int                `json:"offset,omitempty" example:"0"`
+	SourceIDs  []string           `json:"source_ids,omitempty"`
+	BoostTerms map[string]float64 `json:"boost_terms,omitempty" example:"{\"kubernetes\":2.0,\"helm\":1.5}"`
 }
 
 // handleSearch godoc
@@ -664,10 +665,11 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	opts := domain.SearchOptions{
-		Mode:      req.Mode,
-		Limit:     req.Limit,
-		Offset:    req.Offset,
-		SourceIDs: req.SourceIDs,
+		Mode:       req.Mode,
+		Limit:      req.Limit,
+		Offset:     req.Offset,
+		SourceIDs:  req.SourceIDs,
+		BoostTerms: req.BoostTerms,
 	}
 
 	result, err := s.searchService.Search(r.Context(), req.Query, opts)

--- a/internal/adapters/driving/mcp/server.go
+++ b/internal/adapters/driving/mcp/server.go
@@ -175,6 +175,7 @@ type GetDocumentOutput struct {
 	DocumentID string            `json:"document_id" jsonschema_description:"Document ID"`
 	Title      string            `json:"title" jsonschema_description:"Document title"`
 	Content    string            `json:"content" jsonschema_description:"Full document content"`
+	URL        string            `json:"url" jsonschema_description:"URL to open document in source system"`
 	Metadata   map[string]string `json:"metadata" jsonschema_description:"Document metadata"`
 }
 
@@ -217,6 +218,7 @@ func registerGetDocumentTool(server *mcpsdk.Server, documentService driving.Docu
 			DocumentID: doc.ID,
 			Title:      doc.Title,
 			Content:    docContent.Body,
+			URL:        doc.Path,
 			Metadata:   metadata,
 		}
 
@@ -331,7 +333,11 @@ func formatSearchResults(results []SearchResult) string {
 func formatDocument(doc GetDocumentOutput) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "Document: %s\n", doc.Title)
-	fmt.Fprintf(&sb, "ID: %s\n\n", doc.DocumentID)
+	fmt.Fprintf(&sb, "ID: %s\n", doc.DocumentID)
+	if doc.URL != "" {
+		fmt.Fprintf(&sb, "URL: %s\n", doc.URL)
+	}
+	sb.WriteString("\n")
 
 	if len(doc.Metadata) > 0 {
 		sb.WriteString("Metadata:\n")

--- a/internal/core/domain/search.go
+++ b/internal/core/domain/search.go
@@ -13,12 +13,13 @@ const (
 
 // SearchOptions configures a search request
 type SearchOptions struct {
-	Mode        SearchMode `json:"mode"`
-	Limit       int        `json:"limit"`
-	Offset      int        `json:"offset"`
-	SourceIDs   []string   `json:"source_ids,omitempty"`   // Filter by sources
-	DocumentIDs []string   `json:"document_ids,omitempty"` // Filter by specific document IDs
-	Filters     Filters    `json:"filters,omitempty"`
+	Mode        SearchMode         `json:"mode"`
+	Limit       int                `json:"limit"`
+	Offset      int                `json:"offset"`
+	SourceIDs   []string           `json:"source_ids,omitempty"`   // Filter by sources
+	DocumentIDs []string           `json:"document_ids,omitempty"` // Filter by specific document IDs
+	Filters     Filters            `json:"filters,omitempty"`
+	BoostTerms  map[string]float64 `json:"boost_terms,omitempty"` // term -> boost factor
 }
 
 // Filters provides additional search filters

--- a/internal/core/domain/search_test.go
+++ b/internal/core/domain/search_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -156,5 +157,377 @@ func TestRankedChunk(t *testing.T) {
 	}
 	if len(ranked.Highlights) != 1 {
 		t.Errorf("expected 1 highlight, got %d", len(ranked.Highlights))
+	}
+}
+
+func TestSearchOptionsWithBoostTerms(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       SearchOptions
+		wantBoosts int
+		wantNil    bool
+	}{
+		{
+			name: "with boost terms",
+			opts: SearchOptions{
+				Mode:   SearchModeHybrid,
+				Limit:  20,
+				Offset: 0,
+				BoostTerms: map[string]float64{
+					"kubernetes": 2.0,
+					"helm":       1.5,
+					"production": 1.2,
+				},
+			},
+			wantBoosts: 3,
+			wantNil:    false,
+		},
+		{
+			name: "without boost terms",
+			opts: SearchOptions{
+				Mode:   SearchModeTextOnly,
+				Limit:  10,
+				Offset: 0,
+			},
+			wantBoosts: 0,
+			wantNil:    true,
+		},
+		{
+			name: "empty boost terms map",
+			opts: SearchOptions{
+				Mode:       SearchModeSemanticOnly,
+				Limit:      50,
+				Offset:     10,
+				BoostTerms: map[string]float64{},
+			},
+			wantBoosts: 0,
+			wantNil:    false,
+		},
+		{
+			name: "single boost term",
+			opts: SearchOptions{
+				Mode:  SearchModeHybrid,
+				Limit: 20,
+				BoostTerms: map[string]float64{
+					"urgent": 3.0,
+				},
+			},
+			wantBoosts: 1,
+			wantNil:    false,
+		},
+		{
+			name: "boost with filters and source IDs",
+			opts: SearchOptions{
+				Mode:      SearchModeHybrid,
+				Limit:     20,
+				Offset:    0,
+				SourceIDs: []string{"source-1", "source-2"},
+				Filters: Filters{
+					MimeTypes: []string{"text/plain"},
+				},
+				BoostTerms: map[string]float64{
+					"important": 2.5,
+				},
+			},
+			wantBoosts: 1,
+			wantNil:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantNil && tt.opts.BoostTerms != nil {
+				t.Error("expected BoostTerms to be nil")
+			}
+			if !tt.wantNil && tt.wantBoosts > 0 && tt.opts.BoostTerms == nil {
+				t.Error("expected BoostTerms to be non-nil")
+			}
+			if len(tt.opts.BoostTerms) != tt.wantBoosts {
+				t.Errorf("expected %d boost terms, got %d", tt.wantBoosts, len(tt.opts.BoostTerms))
+			}
+
+			// Verify specific boost values if present
+			if tt.wantBoosts > 0 {
+				for term, boost := range tt.opts.BoostTerms {
+					if boost <= 0 {
+						t.Errorf("boost for term %q should be positive, got %f", term, boost)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSearchOptionsBoostTermsValues(t *testing.T) {
+	opts := SearchOptions{
+		Mode:  SearchModeHybrid,
+		Limit: 20,
+		BoostTerms: map[string]float64{
+			"kubernetes": 2.0,
+			"helm":       1.5,
+			"docker":     0.8,
+		},
+	}
+
+	// Test specific boost values
+	if boost, ok := opts.BoostTerms["kubernetes"]; !ok || boost != 2.0 {
+		t.Errorf("kubernetes boost = %v, want 2.0", boost)
+	}
+	if boost, ok := opts.BoostTerms["helm"]; !ok || boost != 1.5 {
+		t.Errorf("helm boost = %v, want 1.5", boost)
+	}
+	if boost, ok := opts.BoostTerms["docker"]; !ok || boost != 0.8 {
+		t.Errorf("docker boost = %v, want 0.8", boost)
+	}
+
+	// Test non-existent term
+	if _, ok := opts.BoostTerms["nonexistent"]; ok {
+		t.Error("nonexistent term should not be in BoostTerms")
+	}
+}
+
+func TestDefaultSearchOptionsHasNoBoostTerms(t *testing.T) {
+	opts := DefaultSearchOptions()
+
+	if opts.BoostTerms != nil {
+		t.Errorf("default SearchOptions should have nil BoostTerms, got %v", opts.BoostTerms)
+	}
+	if len(opts.BoostTerms) != 0 {
+		t.Errorf("default SearchOptions should have 0 boost terms, got %d", len(opts.BoostTerms))
+	}
+}
+
+func TestSearchOptionsJSONMarshaling(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     SearchOptions
+		wantJSON string
+	}{
+		{
+			name: "with boost terms",
+			opts: SearchOptions{
+				Mode:   SearchModeHybrid,
+				Limit:  20,
+				Offset: 0,
+				BoostTerms: map[string]float64{
+					"kubernetes": 2.0,
+					"helm":       1.5,
+				},
+			},
+			wantJSON: `{"mode":"hybrid","limit":20,"offset":0,"filters":{},"boost_terms":{"kubernetes":2.0,"helm":1.5}}`,
+		},
+		{
+			name: "without boost terms omits field",
+			opts: SearchOptions{
+				Mode:   SearchModeTextOnly,
+				Limit:  10,
+				Offset: 0,
+			},
+			wantJSON: `{"mode":"text","limit":10,"offset":0,"filters":{}}`,
+		},
+		{
+			name: "empty boost terms map omits field",
+			opts: SearchOptions{
+				Mode:       SearchModeSemanticOnly,
+				Limit:      50,
+				Offset:     10,
+				BoostTerms: map[string]float64{},
+			},
+			wantJSON: `{"mode":"semantic","limit":50,"offset":10,"filters":{}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.opts)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			// Parse both to compare without key order issues
+			var gotMap, wantMap map[string]any
+			if err := json.Unmarshal(data, &gotMap); err != nil {
+				t.Fatalf("Unmarshal got: %v", err)
+			}
+			if err := json.Unmarshal([]byte(tt.wantJSON), &wantMap); err != nil {
+				t.Fatalf("Unmarshal want: %v", err)
+			}
+
+			// Check all expected fields are present
+			for key, wantVal := range wantMap {
+				gotVal, ok := gotMap[key]
+				if !ok {
+					t.Errorf("missing key %q in marshaled JSON", key)
+					continue
+				}
+
+				// Special handling for nested maps (boost_terms)
+				if key == "boost_terms" {
+					wantBoosts := wantVal.(map[string]any)
+					gotBoosts := gotVal.(map[string]any)
+					if len(gotBoosts) != len(wantBoosts) {
+						t.Errorf("boost_terms length = %d, want %d", len(gotBoosts), len(wantBoosts))
+					}
+					for term, wantBoost := range wantBoosts {
+						if gotBoost, ok := gotBoosts[term]; !ok {
+							t.Errorf("missing boost term %q", term)
+						} else if gotBoost != wantBoost {
+							t.Errorf("boost for %q = %v, want %v", term, gotBoost, wantBoost)
+						}
+					}
+				}
+			}
+
+			// Check no unexpected required fields (skip omitempty fields like source_ids, document_ids)
+			for key := range gotMap {
+				if _, ok := wantMap[key]; !ok {
+					// Allow omitempty fields to be present or absent
+					if key != "source_ids" && key != "document_ids" {
+						t.Errorf("unexpected key %q in marshaled JSON", key)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSearchOptionsJSONUnmarshaling(t *testing.T) {
+	tests := []struct {
+		name         string
+		json         string
+		wantMode     SearchMode
+		wantLimit    int
+		wantBoosts   map[string]float64
+		wantErr      bool
+		validateMore func(*testing.T, SearchOptions)
+	}{
+		{
+			name:       "unmarshal with boost terms",
+			json:       `{"mode":"hybrid","limit":20,"offset":0,"boost_terms":{"kubernetes":2.0,"helm":1.5}}`,
+			wantMode:   SearchModeHybrid,
+			wantLimit:  20,
+			wantBoosts: map[string]float64{"kubernetes": 2.0, "helm": 1.5},
+			wantErr:    false,
+		},
+		{
+			name:       "unmarshal without boost terms",
+			json:       `{"mode":"text","limit":10,"offset":5}`,
+			wantMode:   SearchModeTextOnly,
+			wantLimit:  10,
+			wantBoosts: nil,
+			wantErr:    false,
+		},
+		{
+			name:       "unmarshal with empty boost terms",
+			json:       `{"mode":"semantic","limit":30,"boost_terms":{}}`,
+			wantMode:   SearchModeSemanticOnly,
+			wantLimit:  30,
+			wantBoosts: map[string]float64{},
+			wantErr:    false,
+		},
+		{
+			name:       "unmarshal with single boost term",
+			json:       `{"mode":"hybrid","limit":20,"boost_terms":{"production":3.0}}`,
+			wantMode:   SearchModeHybrid,
+			wantLimit:  20,
+			wantBoosts: map[string]float64{"production": 3.0},
+			wantErr:    false,
+		},
+		{
+			name:       "unmarshal with fractional boost",
+			json:       `{"mode":"hybrid","limit":20,"boost_terms":{"important":1.25}}`,
+			wantMode:   SearchModeHybrid,
+			wantLimit:  20,
+			wantBoosts: map[string]float64{"important": 1.25},
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts SearchOptions
+			err := json.Unmarshal([]byte(tt.json), &opts)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr {
+				if opts.Mode != tt.wantMode {
+					t.Errorf("Mode = %v, want %v", opts.Mode, tt.wantMode)
+				}
+				if opts.Limit != tt.wantLimit {
+					t.Errorf("Limit = %v, want %v", opts.Limit, tt.wantLimit)
+				}
+
+				// Check BoostTerms
+				if tt.wantBoosts == nil {
+					if len(opts.BoostTerms) > 0 {
+						t.Errorf("BoostTerms should be nil or empty, got %v", opts.BoostTerms)
+					}
+				} else {
+					if len(opts.BoostTerms) != len(tt.wantBoosts) {
+						t.Errorf("BoostTerms length = %d, want %d", len(opts.BoostTerms), len(tt.wantBoosts))
+					}
+					for term, wantBoost := range tt.wantBoosts {
+						if gotBoost, ok := opts.BoostTerms[term]; !ok {
+							t.Errorf("missing boost term %q", term)
+						} else if gotBoost != wantBoost {
+							t.Errorf("boost for %q = %v, want %v", term, gotBoost, wantBoost)
+						}
+					}
+				}
+
+				if tt.validateMore != nil {
+					tt.validateMore(t, opts)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchOptionsJSONRoundTrip(t *testing.T) {
+	original := SearchOptions{
+		Mode:      SearchModeHybrid,
+		Limit:     25,
+		Offset:    10,
+		SourceIDs: []string{"source-1", "source-2"},
+		BoostTerms: map[string]float64{
+			"kubernetes": 2.0,
+			"helm":       1.5,
+			"production": 1.2,
+		},
+	}
+
+	// Marshal
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	// Unmarshal
+	var decoded SearchOptions
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	// Verify round-trip
+	if decoded.Mode != original.Mode {
+		t.Errorf("Mode = %v, want %v", decoded.Mode, original.Mode)
+	}
+	if decoded.Limit != original.Limit {
+		t.Errorf("Limit = %v, want %v", decoded.Limit, original.Limit)
+	}
+	if decoded.Offset != original.Offset {
+		t.Errorf("Offset = %v, want %v", decoded.Offset, original.Offset)
+	}
+	if len(decoded.BoostTerms) != len(original.BoostTerms) {
+		t.Errorf("BoostTerms length = %d, want %d", len(decoded.BoostTerms), len(original.BoostTerms))
+	}
+	for term, originalBoost := range original.BoostTerms {
+		if decodedBoost, ok := decoded.BoostTerms[term]; !ok {
+			t.Errorf("missing boost term %q after round-trip", term)
+		} else if decodedBoost != originalBoost {
+			t.Errorf("boost for %q = %v, want %v", term, decodedBoost, originalBoost)
+		}
 	}
 }

--- a/internal/core/domain/sync_event.go
+++ b/internal/core/domain/sync_event.go
@@ -1,0 +1,102 @@
+package domain
+
+import "time"
+
+// SyncEvent represents a logged sync operation for audit and analytics
+// This is an entity (has identity) used to track sync history and performance
+type SyncEvent struct {
+	// ID is the unique identifier for this sync event log entry
+	ID string `json:"id"`
+
+	// TeamID is the team that owns the source being synced
+	TeamID string `json:"team_id"`
+
+	// SourceID is the source that was synced
+	SourceID string `json:"source_id"`
+
+	// SourceName is the display name of the source at sync time
+	SourceName string `json:"source_name"`
+
+	// ProviderType identifies the connector type (github, notion, etc.)
+	ProviderType ProviderType `json:"provider_type"`
+
+	// Status indicates if the sync completed successfully or failed
+	Status SyncStatus `json:"status"`
+
+	// DocumentsAdded is the number of new documents discovered
+	DocumentsAdded int `json:"documents_added"`
+
+	// DocumentsUpdated is the number of existing documents modified
+	DocumentsUpdated int `json:"documents_updated"`
+
+	// DocumentsDeleted is the number of documents removed
+	DocumentsDeleted int `json:"documents_deleted"`
+
+	// ChunksIndexed is the total number of chunks created/updated in the vector store
+	ChunksIndexed int `json:"chunks_indexed"`
+
+	// ErrorCount is the number of errors encountered during sync
+	ErrorCount int `json:"error_count"`
+
+	// ErrorMessage contains the primary error message if Status is failed
+	ErrorMessage string `json:"error_message,omitempty"`
+
+	// DurationSeconds is how long the sync operation took to execute
+	DurationSeconds float64 `json:"duration_seconds"`
+
+	// CreatedAt is when the sync event was logged
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// NewSyncEvent creates a new sync event log entry for a completed sync
+func NewSyncEvent(
+	teamID string,
+	sourceID string,
+	sourceName string,
+	providerType ProviderType,
+	status SyncStatus,
+	stats SyncStats,
+	durationSeconds float64,
+) *SyncEvent {
+	return &SyncEvent{
+		ID:               GenerateID(),
+		TeamID:           teamID,
+		SourceID:         sourceID,
+		SourceName:       sourceName,
+		ProviderType:     providerType,
+		Status:           status,
+		DocumentsAdded:   stats.DocumentsAdded,
+		DocumentsUpdated: stats.DocumentsUpdated,
+		DocumentsDeleted: stats.DocumentsDeleted,
+		ChunksIndexed:    stats.ChunksIndexed,
+		ErrorCount:       stats.Errors,
+		DurationSeconds:  durationSeconds,
+		CreatedAt:        time.Now(),
+	}
+}
+
+// WithError sets the error message for a failed sync event
+func (se *SyncEvent) WithError(errMsg string) *SyncEvent {
+	se.ErrorMessage = errMsg
+	return se
+}
+
+// IsSuccessful returns true if the sync completed without failure
+func (se *SyncEvent) IsSuccessful() bool {
+	return se.Status == SyncStatusCompleted
+}
+
+// IsFailed returns true if the sync failed
+func (se *SyncEvent) IsFailed() bool {
+	return se.Status == SyncStatusFailed
+}
+
+// TotalDocuments returns the total number of documents affected by the sync
+func (se *SyncEvent) TotalDocuments() int {
+	return se.DocumentsAdded + se.DocumentsUpdated + se.DocumentsDeleted
+}
+
+// GetDuration returns the duration as a time.Duration
+func (se *SyncEvent) GetDuration() time.Duration {
+	return time.Duration(se.DurationSeconds * float64(time.Second))
+}

--- a/internal/core/domain/sync_event_test.go
+++ b/internal/core/domain/sync_event_test.go
@@ -1,0 +1,431 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewSyncEvent(t *testing.T) {
+	teamID := "team-123"
+	sourceID := "source-456"
+	sourceName := "Test Source"
+	providerType := ProviderTypeGitHub
+	status := SyncStatusCompleted
+	stats := SyncStats{
+		DocumentsAdded:   10,
+		DocumentsUpdated: 5,
+		DocumentsDeleted: 2,
+		ChunksIndexed:    100,
+		Errors:           0,
+	}
+	duration := 45.5
+
+	event := NewSyncEvent(teamID, sourceID, sourceName, providerType, status, stats, duration)
+
+	if event.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if event.TeamID != teamID {
+		t.Errorf("expected team ID %s, got %s", teamID, event.TeamID)
+	}
+	if event.SourceID != sourceID {
+		t.Errorf("expected source ID %s, got %s", sourceID, event.SourceID)
+	}
+	if event.SourceName != sourceName {
+		t.Errorf("expected source name %s, got %s", sourceName, event.SourceName)
+	}
+	if event.ProviderType != providerType {
+		t.Errorf("expected provider type %s, got %s", providerType, event.ProviderType)
+	}
+	if event.Status != status {
+		t.Errorf("expected status %s, got %s", status, event.Status)
+	}
+	if event.DocumentsAdded != stats.DocumentsAdded {
+		t.Errorf("expected documents added %d, got %d", stats.DocumentsAdded, event.DocumentsAdded)
+	}
+	if event.DocumentsUpdated != stats.DocumentsUpdated {
+		t.Errorf("expected documents updated %d, got %d", stats.DocumentsUpdated, event.DocumentsUpdated)
+	}
+	if event.DocumentsDeleted != stats.DocumentsDeleted {
+		t.Errorf("expected documents deleted %d, got %d", stats.DocumentsDeleted, event.DocumentsDeleted)
+	}
+	if event.ChunksIndexed != stats.ChunksIndexed {
+		t.Errorf("expected chunks indexed %d, got %d", stats.ChunksIndexed, event.ChunksIndexed)
+	}
+	if event.ErrorCount != stats.Errors {
+		t.Errorf("expected error count %d, got %d", stats.Errors, event.ErrorCount)
+	}
+	if event.DurationSeconds != duration {
+		t.Errorf("expected duration %f, got %f", duration, event.DurationSeconds)
+	}
+	if event.CreatedAt.IsZero() {
+		t.Error("expected non-zero CreatedAt")
+	}
+	if event.ErrorMessage != "" {
+		t.Error("expected empty error message for successful sync")
+	}
+}
+
+func TestNewSyncEvent_WithErrors(t *testing.T) {
+	stats := SyncStats{
+		DocumentsAdded:   8,
+		DocumentsUpdated: 3,
+		DocumentsDeleted: 1,
+		ChunksIndexed:    50,
+		Errors:           3,
+	}
+
+	event := NewSyncEvent("team-1", "src-1", "Source", ProviderTypeNotion, SyncStatusCompleted, stats, 60.0)
+
+	if event.ErrorCount != 3 {
+		t.Errorf("expected error count 3, got %d", event.ErrorCount)
+	}
+	if event.ErrorMessage != "" {
+		t.Error("expected empty error message (set via WithError)")
+	}
+}
+
+func TestSyncEvent_WithError(t *testing.T) {
+	event := NewSyncEvent(
+		"team-1",
+		"src-1",
+		"Source",
+		ProviderTypeGitHub,
+		SyncStatusFailed,
+		SyncStats{Errors: 1},
+		30.0,
+	)
+
+	errorMsg := "failed to fetch documents"
+	result := event.WithError(errorMsg)
+
+	if result.ErrorMessage != errorMsg {
+		t.Errorf("expected error message %s, got %s", errorMsg, result.ErrorMessage)
+	}
+	// Verify it returns the same instance
+	if result != event {
+		t.Error("expected WithError to return the same instance")
+	}
+}
+
+func TestSyncEvent_IsSuccessful(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   SyncStatus
+		expected bool
+	}{
+		{
+			name:     "completed status is successful",
+			status:   SyncStatusCompleted,
+			expected: true,
+		},
+		{
+			name:     "failed status is not successful",
+			status:   SyncStatusFailed,
+			expected: false,
+		},
+		{
+			name:     "running status is not successful",
+			status:   SyncStatusRunning,
+			expected: false,
+		},
+		{
+			name:     "idle status is not successful",
+			status:   SyncStatusIdle,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &SyncEvent{Status: tt.status}
+			if got := event.IsSuccessful(); got != tt.expected {
+				t.Errorf("expected IsSuccessful() = %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestSyncEvent_IsFailed(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   SyncStatus
+		expected bool
+	}{
+		{
+			name:     "failed status is failed",
+			status:   SyncStatusFailed,
+			expected: true,
+		},
+		{
+			name:     "completed status is not failed",
+			status:   SyncStatusCompleted,
+			expected: false,
+		},
+		{
+			name:     "running status is not failed",
+			status:   SyncStatusRunning,
+			expected: false,
+		},
+		{
+			name:     "idle status is not failed",
+			status:   SyncStatusIdle,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &SyncEvent{Status: tt.status}
+			if got := event.IsFailed(); got != tt.expected {
+				t.Errorf("expected IsFailed() = %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestSyncEvent_TotalDocuments(t *testing.T) {
+	tests := []struct {
+		name     string
+		added    int
+		updated  int
+		deleted  int
+		expected int
+	}{
+		{
+			name:     "all zeros",
+			added:    0,
+			updated:  0,
+			deleted:  0,
+			expected: 0,
+		},
+		{
+			name:     "only added",
+			added:    10,
+			updated:  0,
+			deleted:  0,
+			expected: 10,
+		},
+		{
+			name:     "only updated",
+			added:    0,
+			updated:  5,
+			deleted:  0,
+			expected: 5,
+		},
+		{
+			name:     "only deleted",
+			added:    0,
+			updated:  0,
+			deleted:  3,
+			expected: 3,
+		},
+		{
+			name:     "mixed documents",
+			added:    10,
+			updated:  5,
+			deleted:  2,
+			expected: 17,
+		},
+		{
+			name:     "large numbers",
+			added:    1000,
+			updated:  500,
+			deleted:  200,
+			expected: 1700,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &SyncEvent{
+				DocumentsAdded:   tt.added,
+				DocumentsUpdated: tt.updated,
+				DocumentsDeleted: tt.deleted,
+			}
+			if got := event.TotalDocuments(); got != tt.expected {
+				t.Errorf("expected TotalDocuments() = %d, got %d", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestSyncEvent_GetDuration(t *testing.T) {
+	tests := []struct {
+		name            string
+		durationSeconds float64
+		expected        time.Duration
+	}{
+		{
+			name:            "zero duration",
+			durationSeconds: 0.0,
+			expected:        0,
+		},
+		{
+			name:            "one second",
+			durationSeconds: 1.0,
+			expected:        time.Second,
+		},
+		{
+			name:            "fractional seconds",
+			durationSeconds: 1.5,
+			expected:        1500 * time.Millisecond,
+		},
+		{
+			name:            "one minute",
+			durationSeconds: 60.0,
+			expected:        time.Minute,
+		},
+		{
+			name:            "large duration",
+			durationSeconds: 3600.0,
+			expected:        time.Hour,
+		},
+		{
+			name:            "milliseconds precision",
+			durationSeconds: 0.123,
+			expected:        123 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &SyncEvent{DurationSeconds: tt.durationSeconds}
+			got := event.GetDuration()
+			if got != tt.expected {
+				t.Errorf("expected GetDuration() = %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestSyncEvent_CompleteSyncScenario(t *testing.T) {
+	// Simulate a complete successful sync
+	teamID := "team-prod-123"
+	sourceID := "github-repo-456"
+	sourceName := "MyOrg/MyRepo"
+	providerType := ProviderTypeGitHub
+	stats := SyncStats{
+		DocumentsAdded:   25,
+		DocumentsUpdated: 10,
+		DocumentsDeleted: 3,
+		ChunksIndexed:    500,
+		Errors:           0,
+	}
+	duration := 120.5
+
+	event := NewSyncEvent(teamID, sourceID, sourceName, providerType, SyncStatusCompleted, stats, duration)
+
+	// Verify event structure
+	if !event.IsSuccessful() {
+		t.Error("expected successful sync")
+	}
+	if event.IsFailed() {
+		t.Error("expected not failed")
+	}
+	if event.TotalDocuments() != 38 {
+		t.Errorf("expected total documents 38, got %d", event.TotalDocuments())
+	}
+	if event.GetDuration() != 120*time.Second+500*time.Millisecond {
+		t.Errorf("expected duration 120.5s, got %v", event.GetDuration())
+	}
+	if event.ErrorMessage != "" {
+		t.Error("expected no error message for successful sync")
+	}
+}
+
+func TestSyncEvent_FailedSyncScenario(t *testing.T) {
+	// Simulate a failed sync
+	teamID := "team-dev-789"
+	sourceID := "notion-workspace-012"
+	sourceName := "Dev Workspace"
+	providerType := ProviderTypeNotion
+	stats := SyncStats{
+		DocumentsAdded:   5,
+		DocumentsUpdated: 2,
+		DocumentsDeleted: 0,
+		ChunksIndexed:    50,
+		Errors:           10,
+	}
+	duration := 45.2
+	errorMsg := "authentication token expired"
+
+	event := NewSyncEvent(teamID, sourceID, sourceName, providerType, SyncStatusFailed, stats, duration).
+		WithError(errorMsg)
+
+	// Verify event structure
+	if event.IsSuccessful() {
+		t.Error("expected not successful")
+	}
+	if !event.IsFailed() {
+		t.Error("expected failed sync")
+	}
+	if event.ErrorCount != 10 {
+		t.Errorf("expected error count 10, got %d", event.ErrorCount)
+	}
+	if event.ErrorMessage != errorMsg {
+		t.Errorf("expected error message %s, got %s", errorMsg, event.ErrorMessage)
+	}
+	if event.TotalDocuments() != 7 {
+		t.Errorf("expected total documents 7, got %d", event.TotalDocuments())
+	}
+}
+
+func TestSyncEvent_ZeroStatsScenario(t *testing.T) {
+	// Simulate a sync with no changes (all documents up to date)
+	event := NewSyncEvent(
+		"team-1",
+		"src-1",
+		"No Changes Source",
+		ProviderTypeGitHub,
+		SyncStatusCompleted,
+		SyncStats{
+			DocumentsAdded:   0,
+			DocumentsUpdated: 0,
+			DocumentsDeleted: 0,
+			ChunksIndexed:    0,
+			Errors:           0,
+		},
+		10.0,
+	)
+
+	if !event.IsSuccessful() {
+		t.Error("expected successful sync even with zero stats")
+	}
+	if event.TotalDocuments() != 0 {
+		t.Errorf("expected total documents 0, got %d", event.TotalDocuments())
+	}
+	if event.ErrorCount != 0 {
+		t.Errorf("expected error count 0, got %d", event.ErrorCount)
+	}
+}
+
+func TestSyncEvent_IDUniqueness(t *testing.T) {
+	// Verify that each new event gets a unique ID
+	event1 := NewSyncEvent("team-1", "src-1", "Source 1", ProviderTypeGitHub, SyncStatusCompleted, SyncStats{}, 10.0)
+	event2 := NewSyncEvent("team-1", "src-1", "Source 1", ProviderTypeGitHub, SyncStatusCompleted, SyncStats{}, 10.0)
+
+	if event1.ID == "" {
+		t.Error("expected non-empty ID for event1")
+	}
+	if event2.ID == "" {
+		t.Error("expected non-empty ID for event2")
+	}
+	if event1.ID == event2.ID {
+		t.Error("expected unique IDs for different events")
+	}
+	// Base64 URL encoding of 16 bytes = 22 chars (same as GenerateID)
+	if len(event1.ID) != 22 {
+		t.Errorf("expected ID length 22, got %d", len(event1.ID))
+	}
+}
+
+func TestSyncEvent_CreatedAtTimestamp(t *testing.T) {
+	before := time.Now()
+	event := NewSyncEvent("team-1", "src-1", "Source", ProviderTypeGitHub, SyncStatusCompleted, SyncStats{}, 10.0)
+	after := time.Now()
+
+	if event.CreatedAt.Before(before) || event.CreatedAt.After(after.Add(time.Second)) {
+		t.Error("expected CreatedAt to be close to now")
+	}
+}

--- a/internal/core/ports/driven/sync_event_repository.go
+++ b/internal/core/ports/driven/sync_event_repository.go
@@ -1,0 +1,21 @@
+package driven
+
+import (
+	"context"
+
+	"github.com/sercha-oss/sercha-core/internal/core/domain"
+)
+
+// SyncEventRepository handles sync event logging and audit trails
+type SyncEventRepository interface {
+	// Save logs a sync event for audit tracking
+	Save(ctx context.Context, event *domain.SyncEvent) error
+
+	// List retrieves recent sync events for a team
+	// Returns up to limit most recent events, ordered by created_at desc
+	List(ctx context.Context, teamID string, limit int) ([]*domain.SyncEvent, error)
+
+	// ListBySource retrieves recent sync events for a specific source
+	// Returns up to limit most recent events, ordered by created_at desc
+	ListBySource(ctx context.Context, sourceID string, limit int) ([]*domain.SyncEvent, error)
+}

--- a/internal/core/services/sync.go
+++ b/internal/core/services/sync.go
@@ -36,6 +36,7 @@ type SyncOrchestrator struct {
 	capabilitySet    *pipeline.CapabilitySet       // Capabilities for pipeline
 	capabilityStore  driven.CapabilityStore        // For fetching capability preferences
 	settingsStore    driven.SettingsStore          // For loading team settings
+	syncEventRepo    driven.SyncEventRepository    // For audit logging of sync events
 	teamID           string                        // Team ID for settings lookup
 }
 
@@ -54,6 +55,7 @@ type SyncOrchestratorConfig struct {
 	CapabilitySet    *pipeline.CapabilitySet       // Capabilities for pipeline
 	CapabilityStore  driven.CapabilityStore        // For fetching capability preferences
 	SettingsStore    driven.SettingsStore          // For loading team settings
+	SyncEventRepo    driven.SyncEventRepository    // For audit logging of sync events
 	TeamID           string                        // Team ID for settings lookup
 }
 
@@ -83,6 +85,7 @@ func NewSyncOrchestrator(cfg SyncOrchestratorConfig) *SyncOrchestrator {
 		capabilitySet:    cfg.CapabilitySet,
 		capabilityStore:  cfg.CapabilityStore,
 		settingsStore:    cfg.SettingsStore,
+		syncEventRepo:    cfg.SyncEventRepo,
 		teamID:           cfg.TeamID,
 	}
 }
@@ -346,6 +349,25 @@ func (o *SyncOrchestrator) SyncSource(ctx context.Context, sourceID string) (*do
 		"chunks_indexed", aggregatedStats.ChunksIndexed,
 		"errors", aggregatedStats.Errors,
 	)
+
+	// Log sync event for audit trail
+	if o.syncEventRepo != nil {
+		syncEvent := domain.NewSyncEvent(
+			o.teamID,
+			sourceID,
+			source.Name,
+			source.ProviderType,
+			syncState.Status,
+			aggregatedStats,
+			duration,
+		)
+		if syncState.Error != "" {
+			syncEvent.WithError(syncState.Error)
+		}
+		if err := o.syncEventRepo.Save(ctx, syncEvent); err != nil {
+			o.logger.Warn("failed to save sync event", "error", err)
+		}
+	}
 
 	success := syncState.Status == domain.SyncStatusCompleted && syncState.Error == ""
 	return &domain.SyncResult{
@@ -745,6 +767,26 @@ func (o *SyncOrchestrator) failSync(
 		syncState.CompletedAt = &now
 		syncState.Error = err.Error()
 		_ = o.syncStore.Save(ctx, syncState)
+	}
+
+	// Log sync event for audit trail
+	if o.syncEventRepo != nil {
+		// Get source info for event logging
+		source, sourceErr := o.sourceStore.Get(ctx, sourceID)
+		if sourceErr == nil {
+			syncEvent := domain.NewSyncEvent(
+				o.teamID,
+				sourceID,
+				source.Name,
+				source.ProviderType,
+				domain.SyncStatusFailed,
+				domain.SyncStats{}, // Empty stats for failed sync
+				duration,
+			).WithError(err.Error())
+			if saveErr := o.syncEventRepo.Save(ctx, syncEvent); saveErr != nil {
+				o.logger.Warn("failed to save sync event", "error", saveErr)
+			}
+		}
 	}
 
 	return &domain.SyncResult{


### PR DESCRIPTION
## Summary

Add URL field to the `get_document` MCP tool output, enabling clients to open documents in their source system.

## Motivation

MCP clients (like Claude Desktop) need a way to provide users with a link to open documents in their original source (GitHub, Notion, Confluence, etc.). The `get_document` tool returns content but previously had no way to link back to the source.

## Changes

- Added `URL` field to `GetDocumentOutput` struct
- Populated URL from `doc.Path` in the get_document tool handler
- Updated `formatDocument()` to display the URL in text output

## Testing

- [x] Unit tests added/updated
- [x] Integration tests pass (if applicable)
- [x] Manual testing performed
- [x] Tested Docker build

**Test commands:**
```bash
go test ./...                    # Unit tests
cd tests/integration && make test  # Integration tests (if applicable)
```

## Checklist

- [x] Code follows project conventions
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in commits with `!`)
- [x] CI passes

## Related Issues

N/A